### PR TITLE
Update www 2022

### DIFF
--- a/conference/MX/www.yml
+++ b/conference/MX/www.yml
@@ -1,4 +1,18 @@
 - title: WWW
+  year: 2021
+  id: www21
+  description: The 30th International World Wide Web Conferences
+  link: https://www2021.thewebconf.org/
+  abstract_deadline: '2020-10-12 23:59:59'
+  deadline: '2020-10-19 23:59:59'
+  timezone: AoE
+  date: April 19-23, 2021
+  place: Ljubljana, Slovenia
+  sub: MX
+  rank: A
+  dblp: www
+  
+- title: WWW
   year: 2022
   id: www22
   description: The 31st International World Wide Web Conference

--- a/conference/MX/www.yml
+++ b/conference/MX/www.yml
@@ -1,13 +1,13 @@
 - title: WWW
-  year: 2021
-  id: www21
-  description: The 30th International World Wide Web Conferences
-  link: https://www2021.thewebconf.org/
-  abstract_deadline: '2020-10-12 23:59:59'
-  deadline: '2020-10-19 23:59:59'
+  year: 2022
+  id: www22
+  description: The 31st International World Wide Web Conference
+  link: https://www2022.thewebconf.org/
+  abstract_deadline: '2021-10-14 23:59:59'
+  deadline: '2021-10-21 23:59:59'
   timezone: AoE
-  date: April 19-23, 2021
-  place: Ljubljana, Slovenia
+  date: April 25-29, 2022
+  place: Lyon, France
   sub: MX
   rank: A
   dblp: www


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- WWW, the web conference, from 2021 to 2022

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://www2022.thewebconf.org/