### PR TITLE
Update CVPR 2022

### DIFF
--- a/conference/AI/cvpr.yml
+++ b/conference/AI/cvpr.yml
@@ -1,0 +1,13 @@
+- title: CVPR
+  year: 2022
+  id: cvpr22
+  description: IEEE/CVF Conference on Computer Vision and Pattern Recognition, CVPR2022
+  link: http://cvpr2022.thecvf.com/
+  abstract_deadline: '2021-11-09 23:59'
+  deadline: '2021-11-16 23:59'
+  timezone: UTC-7
+  date: June 19 - June 24, 2022
+  place: New Orleans, Louisiana
+  sub: AI
+  rank: A
+  dblp: cvpr


### PR DESCRIPTION
### Which conference does this PR update?
- CVPR 2022

### Related URL
- http://cvpr2022.thecvf.com/