### PR TITLE
Update ATC 2022

### DIFF
--- a/conference/DS/atc.yml
+++ b/conference/DS/atc.yml
@@ -12,3 +12,11 @@
       timezone: AoE
       date: July 14–16, 2021
       place: SANTA CLARA, USA
+    - year: 2022
+      id: atc2022
+      link: https://www.usenix.org/conference/atc22/
+      timeline:
+        - deadline: '2022-01-13 23:59:59'
+      timezone: AoE
+      date: July 11–13, 2022
+      place: Omni La Costa Resort & Spa in Carlsbad, CA, USA


### PR DESCRIPTION
Update ATC 2022

### Which conference does this PR update?
- ATC 2022

### Related URL
- https://www.usenix.org/conference/atc22