### PR TITLE
Fixed AoE to UTC in atc.yml.

### DIFF
--- a/conference/DS/atc.yml
+++ b/conference/DS/atc.yml
@@ -17,6 +17,6 @@
       link: https://www.usenix.org/conference/atc22/
       timeline:
         - deadline: '2022-01-13 23:59:59'
-      timezone: AoE
+      timezone: UTC
       date: July 11–13, 2022
       place: Omni La Costa Resort & Spa in Carlsbad, CA, USA


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
- ATC 2022

### Related URL
- https://www.usenix.org/conference/atc22/call-for-papers

### Remarks
- According to the CFP page, the deadline is in `UTC` instead of `AoE`, where the former is 12 hours ahead of the latter. This is a serious mistake that needs immediate repair. Otherwise, those people who rely on this piece of information will miss their chances.