### PR TITLE
Update HPCA2022 and MICRO2021

### DIFF
--- a/conference/DS/hpca.yml
+++ b/conference/DS/hpca.yml
@@ -1,0 +1,17 @@
+- title: HPCA
+  description: IEEE International Symposium on High-Performance Computer Architecture
+  sub: DS
+  rank: A
+  dblp: hpca
+  confs:
+    - year: 2022
+      id: hpca22
+      link: https://hpca-conf.org/2022/
+      timeline:
+        - deadline: '2021-07-23 23:59:59'
+          comment: 'abstract deadline'
+        - deadline: '2021-07-30 23:59:59'
+          comment: 'full paper deadline'
+      timezone: UTC+0
+      date: Feb 12-16, 2022
+      place: Seoul, South Korea

--- a/conference/DS/micro.yml
+++ b/conference/DS/micro.yml
@@ -1,0 +1,17 @@
+- title: MICRO
+  description: IEEE/ACM International Symposium on Microarchitecture
+  sub: DS
+  rank: A
+  dblp: micro
+  confs:
+    - year: 2021
+      id: hpca21
+      link: https://www.microarch.org/micro54/
+      timeline:
+        - deadline: '2021-04-09 23:59:59'
+          comment: 'abstract deadline'
+        - deadline: '2021-04-16 23:59:59'
+          comment: 'full paper deadline'
+      timezone: UTC-7
+      date: Oct 18-22, 2021
+      place: Athens, Greece


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- HPCA 2022
- MICRO 2021

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://hpca-conf.org/2022/
- https://www.microarch.org/micro54/