### PR TITLE
add iccd (CCF-B)  2023 conference

### DIFF
--- a/conference/DS/iccd.yml
+++ b/conference/DS/iccd.yml
@@ -8,8 +8,8 @@
       id: iccd23
       link: https://waset.org/computer-design-conference-in-january-2023-in-zurich
       timeline:
-         - abstract_deadline: '2022-06-01'
-           deadline: '2022-06-01'
+         - abstract_deadline: '2022-06-01 23:59:59'
+           deadline: '2022-06-01 23:59:59'
       timezone: AoE
       date: January 14-15, 2023
       place: Zurich, Switzerland

--- a/conference/DS/iccd.yml
+++ b/conference/DS/iccd.yml
@@ -1,0 +1,15 @@
+- title: ICCD
+  description: International Conference on Computer Design
+  sub: DS
+  rank: B
+  dblp: iccd
+  confs:
+    - year: 2023
+      id: iccd23
+      link: https://waset.org/computer-design-conference-in-january-2023-in-zurich
+      timeline:
+         - abstract_deadline: '2022-06-01'
+           deadline: '2022-06-01'
+      timezone: AoE
+      date: January 14-15, 2023
+      place: Zurich, Switzerland


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
-  ICCD (CCF-B conference) 

### Related URL
<!-- List useful URLs for reviewers to check -->
- ICCD 2023 [Website](https://waset.org/computer-design-conference-in-january-2023-in-zurich)