### PR TITLE
Update information for NDSS 2024

### DIFF
--- a/conference/SC/ndss.yml
+++ b/conference/SC/ndss.yml
@@ -1,7 +1,7 @@
 - title: NDSS
   description: Network and Distributed System Security (NDSS) Symposium
   sub: SC
-  rank: B
+  rank: A
   dblp: ndss
   confs:
     - year: 2022
@@ -30,9 +30,9 @@
       id: ndss24
       link: https://www.ndss-symposium.org/ndss2024/
       timeline:
-        - deadline: '2022-04-19 23:59:59'
+        - deadline: '2023-04-19 23:59:59'
           comment: 'Summer'
-        - deadline: '2022-06-28 23:59:59'
+        - deadline: '2023-06-28 23:59:59'
           comment: 'Fall'
       timezone: UTC-12
       date: February 26 - March 1 2024


### PR DESCRIPTION
In the latest CCF recommended conference list, NDSS has been regarded as CCF-A conference, so I update the rank of NDSS. There is a mistake in the previous information of NDSS 2024. The timeline should be the year of 2023 instead of 2022. See it on https://www.ndss-symposium.org/ndss2024/submissions/call-for-papers/

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- NDSS 2024

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://www.ndss-symposium.org/ndss2024/submissions/call-for-papers/