### PR TITLE
Update CCF Rank of EuroSys 2024

### DIFF
--- a/conference/DS/eurosys.yml
+++ b/conference/DS/eurosys.yml
@@ -1,7 +1,7 @@
 - title: EuroSys
   description: European Conference on Computer Systems
   sub: DS
-  rank: B
+  rank: A
   dblp: eurosys
   confs:
     - year: 2021


### PR DESCRIPTION
The rank of EuroSys recommended by China Computer Federation (CCF), version 2022[1] is upgraded to Level A.

[1] https://www.ccf.org.cn/Academic_Evaluation/By_category/

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- EuroSys

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://www.ccf.org.cn/Academic_Evaluation/By_category/