### PR TITLE
Update MSR 2024

### DIFF
--- a/conference/SE/msr.yml
+++ b/conference/SE/msr.yml
@@ -1,0 +1,15 @@
+- title: MSR
+  description:  International Conference on Mining Software Repositories
+  sub: SE
+  rank: C
+  dblp: msr
+  confs:
+    - year: 2024
+      id: msr24
+      link: https://conf.researchr.org/home/msr-2024
+      timeline:
+        - abstract_deadline: '2023-11-14 23:59:59'
+          deadline: '2023-11-17 23:59:59'
+      timezone: AoE
+      date: April 15-16, 2024
+      place: Lisbon, Portugal


### PR DESCRIPTION
Which conference does this PR update?
- MSR 2024

### Related URL
- https://conf.researchr.org/home/msr-2024