### PR TITLE
Update SIGGRAPH 2024

### DIFF
--- a/conference/CG/sig.yml
+++ b/conference/CG/sig.yml
@@ -11,7 +11,7 @@
         - abstract_deadline: '2024-01-23 22:00:00'
           deadline: '2024-01-24 22:00:00'
       timezone: UTC+0
-      date: 28 July–1 August, 2024
+      date: July 28 - August 1, 2024
       place: Denver
     - year: 2023
       id: siggraph23

--- a/conference/CG/sig.yml
+++ b/conference/CG/sig.yml
@@ -4,6 +4,15 @@
   rank: A
   dblp: siggraph
   confs:
+    - year: 2024
+      id: siggraph24
+      link: https://s2024.siggraph.org/
+      timeline:
+        - abstract_deadline: '2024-01-23 22:00:00'
+          deadline: '2024-01-24 22:00:00'
+      timezone: UTC+0
+      date: 28 July–1 August, 2024
+      place: Denver
     - year: 2023
       id: siggraph23
       link: https://s2023.siggraph.org/


### PR DESCRIPTION

### Which conference does this PR update?

SIGGRAPH 2024


### Related URL

https://s2024.siggraph.org/program/technical-papers/

### Additional Information
The deadlines of SIGGRAPH 2024 has not been updated on this page: https://s2024.siggraph.org/submit-to-siggraph/ , however it is updated on this page: https://s2024.siggraph.org/program/technical-papers/ . The time may be subject to change.

