### PR TITLE
add icmr2024

### DIFF
--- a/conference/CG/icmr.yml
+++ b/conference/CG/icmr.yml
@@ -1,0 +1,14 @@
+- title: ICMR
+  description: ACM SIGMM International Conference on Multimedia Retrieval
+  sub: CG
+  rank: B
+  dblp: mir
+  confs:
+    - year: 2024
+      id: icmr24
+      link: https://icmr2024.org/index.html
+      timeline:
+        - deadline: '2024-02-01 23:59:59'
+      timezone: UTC-12
+      date: June 11-13, 2024
+      place: Phuket, Thailand


### PR DESCRIPTION
### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- I update ICMR 2024 

### Related URL
<!-- List useful URLs for reviewers to check -->
- The conference homepage: https://icmr2024.org/index.html
- The dblp link: http://dblp.uni-trier.de/db/conf/mir/
- The CCF guideline for CG and multimedia: https://www.ccf.org.cn/Academic_Evaluation/CGAndMT/