### PR TITLE
Update ASPLOS 2025 and EuroSys 2025

### DIFF
--- a/conference/DS/asplos.yml
+++ b/conference/DS/asplos.yml
@@ -58,3 +58,19 @@
       timezone: UTC+8
       date: April, 2024
       place: California, U.S.A.
+    - year: 2025
+      id: asplos25
+      link: https://www.asplos-conference.org/asplos-2025-call-for-papers/
+      timeline:
+        - abstract_deadline: '2024-02-23 23:59:59'
+          deadline: '2024-03-01 23:59:59'
+          comment: 'Spring Submission Deadline'
+        - abstract_deadline: '2024-06-17 23:59:59'
+          deadline: '2024-06-24 23:59:59'
+          comment: 'Summer Submission Deadline'
+        - abstract_deadline: '2024-10-11 23:59:59'
+          deadline: '2024-10-18 23:59:59'
+          comment: 'Fall Submission Deadline'
+      timezone: AoE
+      date: March-April, 2025
+      place: Rotterdam, Netherland.

--- a/conference/DS/eurosys.yml
+++ b/conference/DS/eurosys.yml
@@ -46,3 +46,16 @@
       timezone: UTC
       date: April 23-26, 2024
       place: Athens, Greece
+    - year: 2025
+      id: eurosys2025
+      link: https://www.eurosys.org/news/eurosys-2025
+      timeline:
+        - abstract_deadline: '2024-03-14 23:59:59'
+          deadline: '2024-03-21 23:59:59'
+          comment: 'Spring Submission Deadline'
+        - abstract_deadline: '2024-10-15 23:59:59'
+          deadline: '2024-10-22 23:59:59'
+          comment: 'Fall Submission Deadline'
+      timezone: UTC
+      date: March-April, 2025
+      place: Rotterdam, Netherland.


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
ASPLOS 2025
EuroSys 2025

### Related URL
https://www.asplos-conference.org/asplos-2025-call-for-papers/ (ASPLOS 2025)
https://www.eurosys.org/news/eurosys-2025 (EuroSys 2025, time zone has not been clarified so for now I use time zone of EuroSys 2024)