### PR TITLE
Update EuroSys 2025.

### DIFF
--- a/conference/DS/eurosys.yml
+++ b/conference/DS/eurosys.yml
@@ -56,6 +56,6 @@
         - abstract_deadline: '2024-10-15 23:59:59'
           deadline: '2024-10-22 23:59:59'
           comment: 'Fall Submission Deadline'
-      timezone: UTC
+      timezone: AoE
       date: March-April, 2025
-      place: Rotterdam, Netherland.
+      place: Rotterdam, The Netherlands.


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
EuroSys 2025

### Related URL
https://www.eurosys.org/news/eurosys-2025

Update the time zone of EuroSys 2025 according to their edited announcement.