### PR TITLE
Update MICCAI 2024

### DIFF
--- a/conference/MX/miccai.yml
+++ b/conference/MX/miccai.yml
@@ -19,6 +19,6 @@
       timeline:
         - deadline: '2024-03-07 23:59:59'
           comment: Main conference papers
-      timezone: UTC+0
+      timezone: UTC-8
       date: Oct 6-10, 2024
       place: Marrakesh, Morocco


### PR DESCRIPTION
Fix date of MIICAI 24
> Submission deadline:
7 March 2024
(All times are 23:59 Pacific Time)


<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- MICCAI 2024

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://conferences.miccai.org/2024/en/CALL-FOR-PAPERS.html