### PR TITLE
Update SIGGRAPH Asia 2024

### DIFF
--- a/conference/CG/siga.yml
+++ b/conference/CG/siga.yml
@@ -4,6 +4,15 @@
   rank: A
   dblp: siggrapha
   confs:
+    - year: 2024
+      id: siggrapha24
+      link: https://asia.siggraph.org/2024/
+      timeline:
+        - abstract_deadline: '2024-05-12 23:59:00'
+          deadline: '2024-05-19 23:59:00'
+      timezone: UTC-12
+      date: December 3-6, 2024
+      place: Tokyo, Japan
     - year: 2023
       id: siggrapha23
       link: https://asia.siggraph.org/2023/


### PR DESCRIPTION

### Which conference does this PR update?
- SIGGRAPH Asia 2024

### Related URL
- https://asia.siggraph.org/2024/