### PR TITLE
Add PRICAI2024

### DIFF
--- a/conference/AI/pricai.yml
+++ b/conference/AI/pricai.yml
@@ -1,0 +1,14 @@
+- title: PRICAI
+  description: Pacific Rim International Conference on Artificial Intelligence
+  sub: AI
+  rank: C
+  dblp: pricai
+  confs:
+    - year: 2024
+      id: pricai2024
+      link: https://www.pricai.org/2024/
+      timeline:
+        - deadline: '2024-06-12 23:59:59'
+      timezone: UTC-12
+      date: Nov 18-24, 2024
+      place: Kyoto, Japan


### PR DESCRIPTION
Add PRICAI2024

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
--> 

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- CCF-C AI Conf: PRICAI2024(Pacific Rim International Conference on Artificial Intelligence)

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://www.pricai.org/2024/index.php