### PR TITLE
Update isca.yml for isca2025

### DIFF
--- a/conference/DS/isca.yml
+++ b/conference/DS/isca.yml
@@ -40,3 +40,15 @@
         timezone: AoE
         date: June 29-July 3, 2024
         place: Buenos Aires, Argentina
+      - year: 2025
+        id: isca25
+        link: https://iscaconf.org/isca2025/
+        timeline:
+          - deadline: '2024-11-15 23:59:59'
+            comment: abstract deadline
+          - deadline: '2024-11-22 23:59:59'
+            comment: full paper deadline
+        timezone: AoE
+        date: June 21-25, 2025
+        place: Tokyo, Japan
+


### PR DESCRIPTION

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- ISCA 2025  
 The 52nd edition of  International Symposium on Computer Architecture (ISCA)   will be held in Tokyo during June 21 – June 25, 2025.
Abstract Deadline: November 15, 2024 at 11:59 PM AoE
Full Paper Deadline: November 22, 2024 at 11:59 PM AoE


### Related URL
<!-- List useful URLs for reviewers to check -->
- https://iscaconf.org/isca2025/