### PR TITLE
Fix ISSTA's dblp suffix

### DIFF
--- a/conference/SE/issta.yml
+++ b/conference/SE/issta.yml
@@ -5,7 +5,7 @@
       ccf: A
       core: A
       thcpl: A
-    dblp: sigsoft
+    dblp: issta
     confs:
       - year: 2022
         id: issta22


### PR DESCRIPTION
The dblp suffix for ISSTA doesn't seem right.

### Which conference does this PR update?
- ISSTA

### Related URL
- https://dblp.org/db/conf/issta/index.html