### PR TITLE
Update DCC 2025

### DIFF
--- a/conference/DS/dcc.yml
+++ b/conference/DS/dcc.yml
@@ -3,7 +3,7 @@
     sub: DS
     rank:
       ccf: B
-      core: a*
+      core: A*
       thcpl: B
     dblp: dcc
     confs:

--- a/conference/DS/dcc.yml
+++ b/conference/DS/dcc.yml
@@ -12,6 +12,6 @@
         link: https://datacompressionconference.org/
         timeline:
           - deadline: '2024-10-11 23:59:59'
-        timezone: PST
+        timezone: UTC-8
         date: March 18-21, 2025
         place: Snowbird, Utah, U.S.

--- a/conference/DS/dcc.yml
+++ b/conference/DS/dcc.yml
@@ -1,0 +1,17 @@
+  - title: DCC
+    description: Data Compression Conference
+    sub: DS
+    rank:
+      ccf: B
+      core: a*
+      thcpl: B
+    dblp: dcc
+    confs:
+      - year: 2025
+        id: dcc2025
+        link: https://datacompressionconference.org/
+        timeline:
+          - deadline: '2024-10-11 23:59:59'
+        timezone: PST
+        date: March 18-21, 2025
+        place: Snowbird, Utah, U.S.


### PR DESCRIPTION
### Which conference does this PR update?
DCC 2025

### Related URL
https://datacompressionconference.org/
