### PR TITLE
Update SIGMOD 2026

### DIFF
--- a/conference/DB/sigmod.yml
+++ b/conference/DB/sigmod.yml
@@ -90,6 +90,6 @@
           - abstract_deadline: '2025-10-10 23:59:00'
             deadline: '2025-10-17 23:59:00'
             comment: round 4
-        timezone: AoE
+        timezone: UTC-7
         date: May 31-June 5, 2026
         place: Bangalore, India


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- SIGMOD 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://2026.sigmod.org/calls_papers_important_dates.shtml

The DDL for SIGMOD 2026 is set in the Pacific Time zone, consistent with SIGMOD 2024. Therefore, I have changed the 'timezone' from the original 'AoE' to 'UTC-7'.