### PR TITLE
Update SIGMOD 2026

### DIFF
--- a/conference/DB/sigmod.yml
+++ b/conference/DB/sigmod.yml
@@ -90,6 +90,6 @@
           - abstract_deadline: '2025-10-10 23:59:00'
             deadline: '2025-10-17 23:59:00'
             comment: round 4
-        timezone: UTC-7
+        timezone: AoE
         date: May 31-June 5, 2026
         place: Bangalore, India


### PR DESCRIPTION
### Which conference does this PR update?
- SIGMOD 2026

### Related URL
- https://2026.sigmod.org/calls_papers_important_dates.shtml
- time zone is AoE