### PR TITLE
Update SIGGRAPH 2023, 2024 accept rate

### DIFF
--- a/accept_rates/CG/sig.yml
+++ b/accept_rates/CG/sig.yml
@@ -6,3 +6,15 @@
     str: 21.8%(133/610 22')
     rate: 0.218032786885246
     source: https://github.com/emeryberger/csconferences
+  - year: 2023
+    submitted: 611
+    accepted: 212
+    str: 34.7%(212/611 23', 126 journal papers, 86 conference papers)
+    rate: 0.3469721767594108
+    source: https://dl.acm.org/action/showFmPdf?doi=10.1145%2F3588432
+  - year: 2024
+    submitted: 844
+    accepted: 252
+    str: 29.9%(252/844 24', 118 journal papers, 134 conference papers)
+    rate: 0.2985781990521327
+    source: https://dl.acm.org/action/showFmPdf?doi=10.1145%2F3641519

--- a/accept_rates/HI/uist.yml
+++ b/accept_rates/HI/uist.yml
@@ -12,3 +12,9 @@
     str: 25.1%(121/483 23')
     rate: 0.2505176
     source: https://csconfstats.xoveexu.com/
+  - year: 2024
+    submitted: 608
+    accepted: 146
+    str: 24.01%(146/608 24')
+    rate: 0.2401315789473684
+    source: https://dl.acm.org/action/showFmPdf?doi=10.1145%2F3654777


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- SIGGRAPH 2023, 2024 Accept rate

### Related URL
<!-- List useful URLs for reviewers to check -->
- 2024: https://dl.acm.org/action/showFmPdf?doi=10.1145%2F3641519 (Page 15)
- 2023: https://dl.acm.org/action/showFmPdf?doi=10.1145%2F3588432 (Page 10)