### PR TITLE
Update ICDE 2026

### DIFF
--- a/conference/DB/icde.yml
+++ b/conference/DB/icde.yml
@@ -61,3 +61,14 @@
         timezone: AoE
         date: May 19-23, 2025
         place: Hong Kong, China
+      - year: 2026
+        id: icde26
+        link: https://icde2026.github.io/
+        timeline:
+          - deadline: '2025-06-11 23:59:59'
+            comment: first round
+          - deadline: '2025-10-27 23:59:59'
+            comment: second round
+        timezone: AoE
+        date: May 4-8, 2026
+        place: Montréal, Canada


### PR DESCRIPTION
### Which conference does this PR update?
- ICDE 2026

### Related URL
- https://icde2026.github.io/cf-research-papers.html