### PR TITLE
Update and rename its.yml to iss.yml

### DIFF
--- a/conference/HI/iss.yml
+++ b/conference/HI/iss.yml
@@ -1,5 +1,5 @@
-  - title: ITS
-    description: ACM International Conference on Interactive Tabletops and Surfaces
+  - title: ISS
+    description: ACM International Conference on Interactive Surfaces and Spaces
     sub: HI
     rank:
       ccf: B
@@ -8,7 +8,7 @@
     dblp: tabletop
     confs:
       - year: 2025
-        id: its25
+        id: iss25
         link: https://iss.acm.org/2025/
         timeline:
           - deadline: '2025-03-14 23:59:59'


### PR DESCRIPTION
该会议全称于2009年11月-2016年10为ACM International Conference on Interactive Tabletops and Surfaces（简称： ITS） ， 2016年11月改名为现有名称ACM International Conference on Interactive Surfaces and Spaces (简称： ISS)