### PR TITLE
Create sse.yml

### DIFF
--- a/conference/SE/sse.yml
+++ b/conference/SE/sse.yml
@@ -1,0 +1,17 @@
+  - title: SSE
+    description: IEEE International Conference on Software Services Engineering
+    sub: SE
+    rank:
+      ccf: C
+      core: B
+      thcpl: B
+    dblp: IEEEscc
+    confs:
+      - year: 2025
+        id: sse25
+        link: https://services.conferences.computer.org/2025/sse/
+        timeline:
+          - deadline: '2025-03-10 23:00:00'
+        timezone: AoE
+        date: July 7-12, 2025
+        place: Helsinki, Finland


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
-sse
该会议全称于2004年9月-2022年7月为IEEE International Conference on Services Computing (IEEE SCC)， 2023年7月改名为现有名称IEEE International Conference on Software Services Engineering (IEEE SSE)
### Related URL
<!-- List useful URLs for reviewers to check -->
-https://services.conferences.computer.org/2025/sse/