### PR TITLE
Fix oopsla 2026 conf date

### DIFF
--- a/conference/SE/oopsla.yml
+++ b/conference/SE/oopsla.yml
@@ -70,5 +70,5 @@
         - deadline: '2026-03-17 23:59:59'
           comment: Submission Deadline Round 2
       timezone: UTC-12
-      date: October 3-9, 2025
+      date: October 3-9, 2026
       place: Oakland, California, United States


### PR DESCRIPTION
### Which conference does this PR update?
OOPSLA 2026

### Related URL
https://conf.researchr.org/track/splash-2026/oopsla-2026
