### PR TITLE
Update PETS26 date to July 20-25, 2026

### DIFF
--- a/conference/SC/pets.yml
+++ b/conference/SC/pets.yml
@@ -65,5 +65,5 @@
         - deadline: '2026-02-28 23:59:59'
           comment: Issue 4 Paper Submission Deadline
       timezone: AoE
-      date: July, 2026
+      date: July 20-25, 2026
       place: Calgary, Canada


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- PETS2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://petsymposium.org/cfp26.php#:~:text=Symposium%20(PETS%202026)-,July%2020%2D25%2C%202026,-Calgary%2C%20Canada
