### PR TITLE
Update conference details for ICPR2026

### DIFF
--- a/conference/AI/icpr.yml
+++ b/conference/AI/icpr.yml
@@ -7,19 +7,11 @@
       thcpl: B
     dblp: icpr
     confs:
-      - year: 2024
-        id: icpr24
-        link: https://icpr2024.org/
-        timeline:
-          - deadline: '2024-04-10 23:59:59'
-        timezone: UTC-7
-        date: Dec 01-05, 2024
-        place: Kolkata, India
       - year: 2026
         id: icpr26
         link: https://icpr2026.org/
         timeline:
-          - deadline: 'TBD'
-        timezone: AoE
-        date: August 17-21, 2026
+          - deadline: '2025-12-20'
+        timezone: AOE
+        date: Aug 17-22, 2026
         place: Lyon, France


### PR DESCRIPTION
Removed details for the 2024 conference and updated the 2026 conference information.

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- ICPR2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- icpr2026.org
