### PR TITLE
Update ICPP 2026

### DIFF
--- a/conference/DS/icpp.yml
+++ b/conference/DS/icpp.yml
@@ -57,7 +57,7 @@
       link: https://icpp2026.github.io/
       timeline:
         - abstract_deadline: '2026-04-24 23:59:59'
-        - deadline: '2026-05-01 23:59:59'
+          deadline: '2026-05-01 23:59:59'
       timezone: AoE
       date: September 28-October 1, 2026
       place: Singapore


### PR DESCRIPTION

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
ICPP 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
https://icpp2026.github.io/
