### PR TITLE
Add deadline for IEEE SMC 2026

### DIFF
--- a/conference/MX/smc.yml
+++ b/conference/MX/smc.yml
@@ -31,3 +31,11 @@
       timezone: UTC+8
       date: October 5-8, 2025
       place: Vienna, Austria
+    - year: 2026
+      id: smc26
+      link: https://www.ieeesmc2026.org/
+      timeline:
+        - deadline: '2026-03-22 23:59:59'
+      timezone: UTC-7
+      date: October 4-7, 2026
+      place: Bellevue, WA, USA


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- IEEE SMC 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://www.ieeesmc2026.org/call-for-papers
- https://conf.papercept.net/conferences/scripts/start.pl

Please note that the official deadline for 23:59 was in Pacific time (UTC-7 in late March), which may be different than past years. In the PR, I provide the time in the official release (see the second link above for the submission site and time).
