### PR TITLE
Update ACM MM 2026

### DIFF
--- a/conference/CG/mm.yml
+++ b/conference/CG/mm.yml
@@ -58,6 +58,6 @@
       timeline:
         - abstract_deadline: '2026-03-24 11:59:59'
           deadline: '2026-03-31 11:59:59'
-      timezone: UTC-0
+      timezone: UTC-12
       date: November 10-14, 2026
       place: Rio de Janeiro, Brazil


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- ACM MM 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://openreview.net/group?id=acmmm.org/ACMMM/2026/Conference
- openreview 显示的是 UTC-0，鉴于此会议之前都使用 UTC-12，所以进行了换算
