### PR TITLE
Add details for GLSVLSI 2026 conference

### DIFF
--- a/conference/DS/GLSVLSI.yml
+++ b/conference/DS/GLSVLSI.yml
@@ -22,4 +22,4 @@
         - deadline: '2026-03-02 23:59:00'
       timezone: UTC-5
       date: June 22-24, 2026
-      place: Finger Lakes, NY, USA      
+      place: Finger Lakes, NY, USA


### PR DESCRIPTION
Which conference does this PR update?
-GLSVLSI

Related URL
-https://www.glsvlsi.org/

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
-

### Related URL
<!-- List useful URLs for reviewers to check -->
-
