### PR TITLE
Update IROS

### DIFF
--- a/conference/AI/iros.yml
+++ b/conference/AI/iros.yml
@@ -1,5 +1,5 @@
 - title: IROS
-  description: IEEE\RSJ International Conference on Intelligent Robots and Systems
+  description: IEEE/RSJ International Conference on Intelligent Robots and Systems
   sub: AI
   rank:
     ccf: C


### PR DESCRIPTION
Update iros.yml – fix minor typo


### Which conference does this PR update?
- iros 2026 / all

### Related URL
- https://2026.ieee-iros.org
