### PR TITLE
Change EUSIPCO 2026 submission deadline

### DIFF
--- a/conference/DB/eusipco.yml
+++ b/conference/DB/eusipco.yml
@@ -28,7 +28,7 @@
       id: eusipco26
       link: https://eusipco2026.org/
       timeline:
-        - deadline: '2026-02-06 23:59:59'
+        - deadline: '2026-02-13 23:59:59'
       timezone: AoE
       date: August 31 - September 4, 2026
       place: Bruges, Belgium


### PR DESCRIPTION
Updated submission deadline for EUSIPCO 2026.

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- EUSIPCO 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://eusipco2026.org/submissions/#:~:text=6%20February%202026-,13%20February%202026,-Deadline%20for%20Journal
