### PR TITLE
Update NSDI 2027

### DIFF
--- a/conference/NW/nsdi.yml
+++ b/conference/NW/nsdi.yml
@@ -71,5 +71,5 @@
         - abstract_deadline: '2026-09-10 23:59:59'
           deadline: '2026-09-17 23:59:59'
       timezone: UTC-4
-      date: May 11–13, 2027
+      date: May 11-13, 2027
       place: Providence, RI, USA


### PR DESCRIPTION
### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- NSDI 2027

### Related URL
<!-- List useful URLs for reviewers to check -->
- NSDI 2027 [dblp](https://dblp.uni-trier.de/db/conf/nsdi/index.html) [homepage](https://www.usenix.org/conference/nsdi27) [CORE rankings](https://portal.core.edu.au/conf-ranks/1789/)
