### PR TITLE
Add ProbML conference

### DIFF
--- a/conference/AI/probml.yml
+++ b/conference/AI/probml.yml
@@ -1,0 +1,17 @@
+- title: ProbML
+  description: Symposium on Probabilistic Machine Learnin
+  sub: AI
+  rank:
+    ccf: N
+    core: N
+    thcpl: N
+  dblp: probml
+  confs:
+    - year: 2026
+      id: probml2026
+      link: https://probml.cc
+      timeline:
+        - deadline: '2026-03-20 11:59:00'
+      timezone: AoE
+      date: July 5, 2026
+      place: Seoul, South Korea


### PR DESCRIPTION
This PR adds the new [ProbML](https://probml.cc) conference. 

ProbML was previously known as AABI (Symposium on Advances in Approximate Bayesian Inference) and is now called the Symposium on Probabilistic Machine Learning (ProbML).

Previous DBLP name: https://dblp.org/db/conf/aabi

As this is a new conference, there is no DBLP name yet, but `probml` is a likely candidate as it is not taken.

### Which conference does this PR update?
- ProbML

### Related URL
- https://probml.cc
