### PR TITLE
Change ICANN 2026 deadline to March 30

### DIFF
--- a/conference/AI/icann.yml
+++ b/conference/AI/icann.yml
@@ -36,7 +36,7 @@
       id: icann2026
       link: https://e-nns.org/icann2026/
       timeline:
-        - deadline: '2026-03-16 23:59:59'
+        - deadline: '2026-03-30 23:59:59'
       timezone: AoE
       date: Sept 14-17, 2026
       place: Conference center of the School of Psychology, University of Padua, Italy


### PR DESCRIPTION
Updated the deadline for the ICANN 2026 event.

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
-

### Related URL
<!-- List useful URLs for reviewers to check -->
-
