### PR TITLE
Update EUVIP 2026

### DIFF
--- a/conference/AI/euvip.yml
+++ b/conference/AI/euvip.yml
@@ -12,6 +12,6 @@
       link: https://euvip2026.github.io/
       timeline:
         - deadline: "2026-05-21 23:59:59"
-      timezone: CEST
+      timezone: UTC+2
       date: September 28 - October 1, 2026
       place: Luxembourg, Luxembourg

--- a/conference/AI/euvip.yml
+++ b/conference/AI/euvip.yml
@@ -1,0 +1,17 @@
+- title: EUVIP
+  description: European Conference on Visual Information Processing
+  sub: AI
+  rank:
+    ccf: N
+    core: N
+    thcpl: N
+  dblp: euvip
+  confs:
+    - year: 2026
+      id: euvip26
+      link: https://euvip2026.github.io/
+      timeline:
+        - deadline: "2026-05-21 23:59:59"
+      timezone: CEST
+      date: September 28 - October 1, 2026
+      place: Luxembourg, Luxembourg


### PR DESCRIPTION
### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- EUVIP 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- Conference website: https://euvip2026.github.io/
- DBLP: https://dblp.org/db/conf/euvip
- LinkedIn page: https://www.linkedin.com/company/euvip-2026/
- X profile: https://x.com/Euvip2026
- Bluesky profile: https://bsky.app/profile/euvip2026.bsky.social