### PR TITLE
Update MobiHoc 2026 deadlines

### DIFF
--- a/conference/NW/mobihoc.yml
+++ b/conference/NW/mobihoc.yml
@@ -20,8 +20,8 @@
       id: mobihoc26
       link: https://www.sigmobile.org/mobihoc/2026/
       timeline:
-        - abstract_deadline: '2026-03-30 23:59:59'
-          deadline: '2026-04-06 23:59:59'
+        - abstract_deadline: '2026-04-13 23:59:59'
+          deadline: '2026-04-20 23:59:59'
       timezone: AoE
       date: November 23-26, 2026
       place: Tokyo, Japan


### PR DESCRIPTION
### Which conference does this PR update?
- MobiHoc 2026

### Related URL
- https://www.sigmobile.org/mobihoc/2026/
