### PR TITLE
ICDM 2026: label tracks and add Demo Track deadline

### DIFF
--- a/conference/DB/icdm.yml
+++ b/conference/DB/icdm.yml
@@ -53,6 +53,9 @@
       timeline:
         - abstract_deadline: '2026-05-30 23:59:59'
           deadline: '2026-06-06 23:59:59'
+          comment: 'Research & Applied Track'
+        - deadline: '2026-08-20 23:59:59'
+          comment: 'Demo Track'
       timezone: AoE
       date: November 12-15, 2026
       place: Shenyang, China


### PR DESCRIPTION
## Summary

Updates `conference/DB/icdm.yml` for ICDM 2026 to:

1. Label the existing 2026-06-06 AoE deadline as **Research & Applied Track** (both tracks share this deadline per the official Applied Track CFP — a paper is submitted to only one of the two tracks).
2. Add the **Demo Track** deadline (2026-08-20 AoE) as a second timeline entry so Demo submitters see the correct date.

## Sources

- Applied Track CFP: http://icdm2026.neu.edu.cn/CallforAppliedTrackPapers/list.htm
  - Paper submission: June 6, 2026 AoE
  - Notification: August 16, 2026
  - Camera ready: September 16, 2026
- Demo CFP: http://icdm2026.neu.edu.cn/11669/list.htm
  - Demo paper submission: August 20, 2026 AoE
  - Notification: September 18, 2026
- Main site: http://icdm2026.neu.edu.cn/

## Diff

```yaml
    - year: 2026
      id: icdm2026
      link: http://icdm2026.neu.edu.cn/
      timeline:
        - abstract_deadline: '2026-05-30 23:59:59'
          deadline: '2026-06-06 23:59:59'
          comment: 'Research & Applied Track'
        - deadline: '2026-08-20 23:59:59'
          comment: 'Demo Track'
      timezone: AoE
      date: November 12-15, 2026
      place: Shenyang, China
```

The multi-deadline + `comment` pattern matches the schema documented in the README (see SIGMOD 2022 example).