### PR TITLE
Update four security conferences

### DIFF
--- a/conference/SC/csfw.yml
+++ b/conference/SC/csfw.yml
@@ -1,5 +1,5 @@
 - title: CSFW
-  description: IEEE Computer Security Foundations Workshop
+  description: IEEE Computer Security Foundations Symposium
   sub: SC
   rank:
     ccf: B

--- a/conference/SC/dimva.yml
+++ b/conference/SC/dimva.yml
@@ -3,7 +3,7 @@
   sub: SC
   rank:
     ccf: C
-    core: C
+    core: B
     thcpl: B
   dblp: dimva
   confs:
@@ -44,9 +44,9 @@
       id: dimva26
       link: https://www.dimva.org/dimva2026/
       timeline:
-        - deadline: '2025-12-03 23:59:59'
+        - deadline: '2025-12-10 23:59:59'
           comment: Cycle 1 submission deadline
-        - deadline: '2026-02-11 23:59:59'
+        - deadline: '2026-02-18 23:59:59'
           comment: Cycle 2 submission deadline
       timezone: AoE
       date: July 1-3, 2026

--- a/conference/SC/fse.yml
+++ b/conference/SC/fse.yml
@@ -3,7 +3,7 @@
   sub: SC
   rank:
     ccf: B
-    core: N
+    core: B
     thcpl: B
   dblp: fse
   confs:

--- a/conference/SC/srds.yml
+++ b/conference/SC/srds.yml
@@ -55,9 +55,9 @@
       id: srds26
       link: https://srds-conference.org/
       timeline:
-        - deadline: '2026-04-24 23:59:59'
-          comment: Abstract Submission
         - deadline: '2026-05-01 23:59:59'
+          comment: Abstract Submission
+        - deadline: '2026-05-08 23:59:59'
           comment: Full Paper Submission
       timezone: AoE
       date: September 21-25, 2026


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- FSE (Core ranking info)
- SRDS 2026
- DIMVA (Core ranking info)
- CSFW (Conference name)

Note: I would suggest changing CSFW to CSF generally since it has been "promoted" to a symposium from a workshop. See the link below.

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://portal.core.edu.au/conf-ranks/?search=fse&by=all&source=ICORE2026&sort=atitle&page=1
- https://srds-conference.org/
- https://portal.core.edu.au/conf-ranks/?search=dimva&by=all&source=ICORE2026&sort=atitle&page=1
- https://csf2026.ieee-security.org/
