### PR TITLE
Update cgo.yml

### DIFF
--- a/conference/DS/cgo.yml
+++ b/conference/DS/cgo.yml
@@ -7,6 +7,28 @@
     thcpl: B
   dblp: cgo
   confs:
+    - year: 2027
+      id: cgo2027
+      link: https://conf.researchr.org/home/cgo-2027
+      timeline:
+        - deadline: '2026-06-11 23:59:59'
+          comment: 'First Submission'
+        - deadline: '2026-09-10 23:59:59'
+          comment: 'Second Submission'
+      timezone: AoE
+      date: TBD
+      place: Salt Lake City, Utah, USA
+    - year: 2026
+      id: cgo2026
+      link: https://conf.researchr.org/home/cgo-2026
+      timeline:
+        - deadline: '2025-05-29 23:59:59'
+          comment: 'First Submission'
+        - deadline: '2025-09-11 23:59:59'
+          comment: 'Second Submission'
+      timezone: AoE
+      date: January 31 - 4 February, 2026
+      place: Sydney, Australia
     - year: 2025
       id: cgo2025
       link: https://conf.researchr.org/home/cgo-2025
@@ -23,14 +45,3 @@
       timezone: AoE
       date: March 2-6, 2024
       place: Edinburgh, United Kingdom
-    - year: 2026
-      id: cgo2026
-      link: https://conf.researchr.org/home/cgo-2026
-      timeline:
-        - deadline: '2025-05-29 23:59:59'
-          comment: 'First Submission'
-        - deadline: '2025-09-11 23:59:59'
-          comment: 'Second Submission'
-      timezone: AoE
-      date: January 31 - 4 February, 2026
-      place: Sydney, Australia


### PR DESCRIPTION
### Which conference does this PR update?
- CGO 2027

### Related URL
- Call for Papers: https://conf.researchr.org/track/cgo-2027/cgo-2027-papers
- Conference homepage: https://conf.researchr.org/home/cgo-2027

### Summary
Add CGO 2027 entry to `conference/DS/cgo.yml` based on the official Call for Papers.

- **Place**: Salt Lake City, Utah, USA (co-located with HPCA, PPoPP, CC)
- **Date**: TBD (not yet announced on the conference site)
- **Timezone**: AoE
- **Two submission rounds**:
  - First Submission: 2026-06-11 23:59:59 AoE
  - Second Submission: 2026-09-10 23:59:59 AoE