### PR TITLE
Update AAAI 2027

### DIFF
--- a/conference/AI/aaai.yml
+++ b/conference/AI/aaai.yml
@@ -56,8 +56,8 @@
       id: aaai27
       link: https://aaai.org/conference/aaai/aaai-27/
       timeline:
-        - abstract_deadline: 'TBD'
-          deadline: 'TBD'
+        - abstract_deadline: '2026-07-20 23:59:59'
+          deadline: '2026-07-27 23:59:59'
       timezone: UTC-12
       date: February 16-23, 2027
       place: Montréal, Québec, Canada


### PR DESCRIPTION
### Which conference does this PR update?
- AAAI 2027

### Related URL
- https://openreview.net/group?id=AAAI.org/2027/Conference
