### PR TITLE
Update EUVIP 2026 deadline.

### DIFF
--- a/conference/AI/euvip.yml
+++ b/conference/AI/euvip.yml
@@ -11,7 +11,7 @@
       id: euvip26
       link: https://euvip2026.github.io/
       timeline:
-        - deadline: "2026-05-21 23:59:59"
+        - deadline: "2026-06-05 23:59:59"
       timezone: UTC+2
       date: September 28 - October 1, 2026
       place: Luxembourg, Luxembourg


### PR DESCRIPTION
## Which conference does this PR update?

- EUVIP 2026

## Related URL

- Conference website: https://euvip2026.github.io/
- DBLP: https://dblp.org/db/conf/euvip
- LinkedIn page: https://www.linkedin.com/company/euvip-2026/
- X profile: https://x.com/Euvip2026
- Bluesky profile: https://bsky.app/profile/euvip2026.bsky.social

