### PR TITLE
Update DAI 2026

### DIFF
--- a/conference/AI/dai.yml
+++ b/conference/AI/dai.yml
@@ -15,3 +15,19 @@
       timezone: UTC-12
       date: November 21-24, 2025
       place: London, United Kingdom
+    - year: 2026
+      id: dai2026
+      link: https://www.adai.ai/dai/2026/
+      timeline:
+        - deadline: '2026-06-30 23:59:59'
+          comment: Workshop Proposal
+        - deadline: '2026-07-01 23:59:59'
+          comment: Sister Conference Track (rolling)
+        - abstract_deadline: '2026-07-27 23:59:59'
+          deadline: '2026-08-03 23:59:59'
+          comment: Research & Industry Track
+        - deadline: '2026-08-10 23:59:59'
+          comment: AI Paper Track
+      timezone: UTC-12
+      date: November 29 - December 2, 2026
+      place: Hong Kong


### PR DESCRIPTION
### Which conference does this PR update?
- DAI 2026

### Related URL
- https://www.adai.ai/dai/2026/