### PR TITLE
Update TCC 2026

### DIFF
--- a/conference/SC/tcc.yml
+++ b/conference/SC/tcc.yml
@@ -39,3 +39,11 @@
       timezone: AoE
       date: December 1-5, 2025
       place: Aarhus, Denmark
+    - year: 2026
+      id: tcc26
+      link: https://tcc.iacr.org/2026/
+      timeline:
+        - deadline: '2026-05-19 23:59:59'
+      timezone: AoE
+      date: November 10-13, 2026
+      place: New York City, USA


### PR DESCRIPTION
### Which conference does this PR update?
- TCC 2026

### Related URL
- https://tcc.iacr.org/2026/