### PR TITLE
Update nlpcc 2026

### DIFF
--- a/conference/AI/nlpcc.yml
+++ b/conference/AI/nlpcc.yml
@@ -19,7 +19,7 @@
       id: nlpcc2026
       link: http://tcci.ccf.org.cn/conference/2026/
       timeline:
-        - deadline: '2026-05-26 23:59:59'
+        - deadline: '2026-06-20 23:59:59'
       timezone: UTC+8
       date: November 3-5, 2026
       place: Macau, China

--- a/conference/CG/icassp.yml
+++ b/conference/CG/icassp.yml
@@ -51,7 +51,7 @@
       id: icassp27
       link: https://2027.ieeeicassp.org/
       timeline:
-        - deadline: 'TBD'
+        - deadline: '2026-09-16 23:59:59'
       timezone: UTC-12
       date: May 16-21, 2027
       place: Toronto, Canada


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update nlpcc 2026
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- nlpcc 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- extended paper submission deadline: http://tcci.ccf.org.cn/conference/2026/important-dates/
