### PR TITLE
Fix: show abstract deadline note even when a comment is set

### DIFF
--- a/src/components/showtable.rs
+++ b/src/components/showtable.rs
@@ -329,12 +329,14 @@ pub fn ShowTable() -> impl IntoView {
                                             .with_timezone(&current_timezone)
                                             .format("%b %e, %Y")
                                             .to_string();
-                                        if item.comment.is_none() {
-                                            item.comment = Some(format!(
-                                                "abstract deadline on {}.",
-                                                formatted_abs_ddl
-                                            ));
-                                        }
+                                        let abs_note =
+                                            format!("abstract deadline on {}.", formatted_abs_ddl);
+                                        item.comment = Some(match &item.comment {
+                                            Some(existing) if !existing.is_empty() => {
+                                                format!("{} ({})", existing, abs_note)
+                                            }
+                                            _ => abs_note,
+                                        });
                                     }
                                 }
 

--- a/src/components/showtable.rs
+++ b/src/components/showtable.rs
@@ -330,12 +330,12 @@ pub fn ShowTable() -> impl IntoView {
                                             .format("%b %e, %Y")
                                             .to_string();
                                         let abs_note =
-                                            format!("abstract deadline on {}.", formatted_abs_ddl);
+                                            format!("abstract deadline on {}", formatted_abs_ddl);
                                         item.comment = Some(match &item.comment {
                                             Some(existing) if !existing.is_empty() => {
-                                                format!("{} ({})", existing, abs_note)
+                                                format!("{} ({}).", existing, abs_note)
                                             }
-                                            _ => abs_note,
+                                            _ => format!("{}.", abs_note),
                                         });
                                     }
                                 }


### PR DESCRIPTION
## What

Conferences that specify both an `abstract_deadline` and a `comment` (e.g. S&P, ICSE, USENIX Security, EuroSys, SIGMOD) were silently dropping the abstract deadline note from the displayed NOTE — only the comment was shown.

## Why

The render logic only generated the "abstract deadline on …" note when the
timeline entry had no comment:

```rust
if item.comment.is_none() {
    item.comment = Some(format!("abstract deadline on {}.", ...));
}
```

## Demonstration

Before the fix:

The "first paper submission deadline" note takes effect, though there is an abstract deadline, it's not shown.

<img width="1193" height="138" alt="image" src="https://github.com/user-attachments/assets/55e3d72d-2f3b-4891-9ad7-eab1bddb33b3" />

After the fix:

Both are shown, more informative and comply with the intuition.

<img width="1191" height="156" alt="image" src="https://github.com/user-attachments/assets/7d24275a-db66-46a4-87db-e036f3c9b493" />

