### PR TITLE
Fix ACML information and timezone problem for VLDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Description of the fields:
    </tr>
    <tr>
       <td colspan="2"><code>timezone</code>*</td>
-      <td>Timezone of deadline, currently support <code>UTC-12</code> ~ <code>UTC+12</code> & <code>AoE</code></td>
+      <td>Timezone of deadline, currently support <code>UTC-12</code> ~ <code>UTC+12</code>, <code>AoE</code> & <code>PT</code> (US Pacific Time, auto-adjusts for daylight saving)</td>
    </tr>
    <tr>
       <td colspan="2"><code>date</code>*</td>

--- a/conference-yaml-schema.yml
+++ b/conference-yaml-schema.yml
@@ -137,6 +137,7 @@ items:
               - UTC+11
               - UTC+12
               - AoE
+              - PT
           date:
             description: When the main conference is happening, e.g., Mar 12-16, 2021
             type: string

--- a/conference/AI/acml.yml
+++ b/conference/AI/acml.yml
@@ -46,10 +46,10 @@
       id: acml26
       link: https://www.acml-conf.org/2026/
       timeline:
-        - deadline: '2026-06-06 23:59:59'
+        - deadline: '2026-06-20 23:59:59'
           comment: 'Journal Track'
         - deadline: '2025-06-26 23:59:59'
           comment: 'Conference Track'
-      timezone: UTC-7
+      timezone: AoE
       date: December 1-4, 2026
       place: Melbourne, Australia

--- a/conference/DB/vldb.yml
+++ b/conference/DB/vldb.yml
@@ -23,7 +23,7 @@
         - deadline: '2021-01-01 17:00:00'
         - deadline: '2021-02-01 17:00:00'
         - deadline: '2021-03-01 17:00:00'
-      timezone: UTC-7
+      timezone: PT
       date: August 16-20, 2021
       place: Copenhagen, Denmark
     - year: 2022
@@ -42,7 +42,7 @@
         - deadline: '2022-01-01 17:00:00'
         - deadline: '2022-02-01 17:00:00'
         - deadline: '2022-03-01 17:00:00'
-      timezone: UTC-7
+      timezone: PT
       date: September 05-09, 2022
       place: Sydney, Australia
     - year: 2023
@@ -61,7 +61,7 @@
         - deadline: '2023-01-01 17:00:00'
         - deadline: '2023-02-01 17:00:00'
         - deadline: '2023-03-01 17:00:00'
-      timezone: UTC-7
+      timezone: PT
       date: August 28 - September 01, 2023
       place: Vancouver, Canada
     - year: 2024
@@ -80,7 +80,7 @@
         - deadline: '2024-01-01 17:00:00'
         - deadline: '2024-02-01 17:00:00'
         - deadline: '2024-03-01 17:00:00'
-      timezone: UTC-7
+      timezone: PT
       date: August 25-29, 2024
       place: Guangzhou, China (and hybrid)
     - year: 2025
@@ -99,7 +99,7 @@
         - deadline: '2025-01-01 17:00:00'
         - deadline: '2025-02-01 17:00:00'
         - deadline: '2025-03-01 17:00:00'
-      timezone: UTC-7
+      timezone: PT
       date: September 1-5, 2025
       place: London, United Kingdom
     - year: 2026
@@ -118,7 +118,7 @@
         - deadline: '2026-01-01 17:00:00'
         - deadline: '2026-02-01 17:00:00'
         - deadline: '2026-03-01 17:00:00'
-      timezone: UTC-7
+      timezone: PT
       date: August 31 - September 4, 2026
       place: Boston, MA, USA
     - year: 2027
@@ -149,6 +149,6 @@
           deadline: '2027-02-01 17:00:00'
         - abstract_deadline: '2027-02-25 17:00:00'
           deadline: '2027-03-01 17:00:00'
-      timezone: UTC-7
+      timezone: PT
       date: August 23 - August 27, 2027
       place: Athens, Greece

--- a/src/components/showtable.rs
+++ b/src/components/showtable.rs
@@ -6,7 +6,7 @@ use crate::components::countdown::CountDown;
 use crate::components::subscription_modal::*;
 use crate::components::timeline::*;
 use crate::components::timezone::*;
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, Datelike, Duration, FixedOffset, NaiveDate};
 use leptos::prelude::*;
 use serde_json;
 use std::collections::HashMap;
@@ -146,16 +146,13 @@ pub fn ShowTable() -> impl IntoView {
         let _ = page.get();
 
         let (current_time, _) = get_browser_time_and_timezone();
-        let utc_map = load_utc_map();
 
         all_conf_list.update(|conferences| {
             for item in conferences.iter_mut() {
                 if item.deadline != "TBD" {
-                    let tz_str = normalize_timezone(&item.timezone);
-
-                    if let Some(tz_offset) = utc_map.get(&tz_str) {
-                        let ddl_str = parse_deadline_to_rfc3339(&item.deadline, tz_offset);
-
+                    if let Some(ddl_str) =
+                        parse_deadline_to_rfc3339(&item.deadline, &item.timezone)
+                    {
                         if let Ok(ddl_datetime) = DateTime::parse_from_rfc3339(&ddl_str) {
                             let diff = ddl_datetime.signed_duration_since(current_time);
                             if diff.num_milliseconds() <= 0 {
@@ -180,7 +177,6 @@ pub fn ShowTable() -> impl IntoView {
         time_zone.set(get_timezone_name().unwrap());
 
         spawn_local(async move {
-            let utc_map = load_utc_map();
             let rank_options: HashMap<&str, &str> = RANK_OPTIONS.iter().cloned().collect();
 
             let (current_time, current_timezone) = get_browser_time_and_timezone();
@@ -205,25 +201,33 @@ pub fn ShowTable() -> impl IntoView {
                             let mut ddl_vec = Vec::<TimePoint>::new();
 
                             for timeline_item in year_conf.timeline.iter() {
-                                let tz_offset = utc_map.get(&year_conf.timezone).unwrap();
-
-                                let ddl_str = parse_deadline_to_rfc3339(&timeline_item.deadline, tz_offset);
+                                let tz = &year_conf.timezone;
 
                                 // abstract type:0 submission type:1
                                 if let Some(abs_ddl) = timeline_item.abstract_deadline.clone() {
-                                    let abs_ddl_str = parse_deadline_to_rfc3339(&abs_ddl, tz_offset);
-
-                                    if let Ok(abs_ddl_datetime) =
-                                        DateTime::parse_from_rfc3339(&abs_ddl_str)
+                                    if let Some(abs_ddl_str) =
+                                        parse_deadline_to_rfc3339(&abs_ddl, tz)
                                     {
-                                        ddl_vec.push(TimePoint {
-                                            timepoint: abs_ddl_datetime
-                                                .with_timezone(&current_timezone)
-                                                .clone(),
-                                            r#type: 0,
-                                        });
+                                        if let Ok(abs_ddl_datetime) =
+                                            DateTime::parse_from_rfc3339(&abs_ddl_str)
+                                        {
+                                            ddl_vec.push(TimePoint {
+                                                timepoint: abs_ddl_datetime
+                                                    .with_timezone(&current_timezone)
+                                                    .clone(),
+                                                r#type: 0,
+                                            });
+                                        }
                                     }
                                 }
+
+                                let ddl_str = match parse_deadline_to_rfc3339(
+                                    &timeline_item.deadline,
+                                    tz,
+                                ) {
+                                    Some(s) => s,
+                                    None => continue,
+                                };
 
                                 if let Ok(ddl_datetime) = DateTime::parse_from_rfc3339(&ddl_str) {
                                     ddl_vec.push(TimePoint {
@@ -298,12 +302,10 @@ pub fn ShowTable() -> impl IntoView {
                             continue;
                         }
 
-                        let tz_str = normalize_timezone(&item.timezone);
-
                         // 4. Calculate deadlines and remaining time
-                        if let Some(tz_offset) = utc_map.get(&tz_str) {
-                            let ddl_str = parse_deadline_to_rfc3339(&item.deadline, tz_offset);
-
+                        if let Some(ddl_str) =
+                            parse_deadline_to_rfc3339(&item.deadline, &item.timezone)
+                        {
                             if let Ok(ddl_datetime) = DateTime::parse_from_rfc3339(&ddl_str) {
                                 // Convert to browser local time and format
                                 let local_ddl_datetime =
@@ -321,7 +323,9 @@ pub fn ShowTable() -> impl IntoView {
 
                                 // Handle abstract deadline
                                 if let Some(abs_ddl) = &item.abstract_deadline {
-                                    let abs_ddl_str = parse_deadline_to_rfc3339(abs_ddl, tz_offset);
+                                    if let Some(abs_ddl_str) =
+                                        parse_deadline_to_rfc3339(abs_ddl, &item.timezone)
+                                    {
                                     if let Ok(abs_datetime) =
                                         DateTime::parse_from_rfc3339(&abs_ddl_str)
                                     {
@@ -337,6 +341,7 @@ pub fn ShowTable() -> impl IntoView {
                                             }
                                             _ => format!("{}.", abs_note),
                                         });
+                                    }
                                     }
                                 }
 
@@ -1053,17 +1058,53 @@ fn normalize_timezone(tz: &str) -> String {
     }
 }
 
-fn parse_deadline_to_rfc3339(deadline: &str, tz_offset: &str) -> String {
-    if deadline.contains(' ') {
+/// Nth (1-indexed) Sunday of the given month/year.
+fn nth_sunday(year: i32, month: u32, n: u32) -> Option<NaiveDate> {
+    let first = NaiveDate::from_ymd_opt(year, month, 1)?;
+    let days_to_first_sunday = (7 - first.weekday().num_days_from_sunday()) % 7;
+    Some(first + Duration::days(days_to_first_sunday as i64 + 7 * (n as i64 - 1)))
+}
+
+/// Whether the given date falls within US daylight saving time, which runs from
+/// the second Sunday in March to the first Sunday in November.
+fn is_us_dst(date: NaiveDate) -> bool {
+    let year = date.year();
+    match (nth_sunday(year, 3, 2), nth_sunday(year, 11, 1)) {
+        (Some(start), Some(end)) => date >= start && date < end,
+        _ => false,
+    }
+}
+
+/// Resolve a timezone label to a fixed `+HH:MM` / `-HH:MM` offset for a given
+/// deadline date. Labels with a constant offset (`UTC-8`, `AoE`, ...) ignore the
+/// date; daylight-saving labels such as `PT` (US Pacific Time) pick UTC-7 during
+/// DST and UTC-8 otherwise based on the deadline date.
+fn resolve_tz_offset(tz: &str, date: &str) -> Option<String> {
+    if tz == "PT" {
+        let naive = NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?;
+        return Some(if is_us_dst(naive) {
+            "-07:00".to_string()
+        } else {
+            "-08:00".to_string()
+        });
+    }
+    let tz_str = normalize_timezone(tz);
+    get_utc_map().get(&tz_str).cloned()
+}
+
+fn parse_deadline_to_rfc3339(deadline: &str, tz: &str) -> Option<String> {
+    let date_part = deadline.split(' ').nth(0).unwrap_or(deadline);
+    let tz_offset = resolve_tz_offset(tz, date_part)?;
+    Some(if deadline.contains(' ') {
         format!(
             "{}T{}{}",
-            deadline.split(' ').nth(0).unwrap_or(""),
+            date_part,
             deadline.split(' ').nth(1).unwrap_or("00:00:00"),
             tz_offset
         )
     } else {
         format!("{}T23:59:59{}", deadline, tz_offset)
-    }
+    })
 }
 
 const RANK_OPTIONS: &[(&str, &str)] = &[("A", "CCF A"), ("B", "CCF B"), ("C", "CCF C"), ("N", "Non-CCF")];
@@ -1094,11 +1135,6 @@ fn get_utc_map() -> &'static HashMap<String, String> {
         utc_map.insert("UTC".to_string(), "+00:00".to_string());
         utc_map
     })
-}
-
-#[allow(dead_code)]
-fn load_utc_map() -> HashMap<String, String> {
-    get_utc_map().clone()
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Closes #1553 Closes #1449 

## 1 Update ACML 2026 Information

Update the deadline and time zone.

## 2 Support PT (Pacific Time) timezone

### Problem

PT is **UTC-7 during daylight saving** (2nd Sunday of March → 1st Sunday of November) and **UTC-8 otherwise**. A single fixed offset can't express this. VLDB's rolling submission deadlines run April→March, straddling the DST boundary — so the previous `timezone: UTC-7` made every winter deadline (Nov–Mar) wrong by one hour.

### Change

- Added `PT` as a supported timezone. Its offset is resolved **per deadline date** using the US daylight-saving rules, instead of from the static offset map.
- `parse_deadline_to_rfc3339` now takes the raw timezone label and resolves the offset internally, so each deadline/abstract deadline is computed against its own date.
- Updated the YAML schema, README, and switched `vldb.yml` to `PT`.

### Compatibility

All other timezones (`UTC±N`, `AoE`, `UTC`) are untouched. I verified the new resolution path produces **byte-identical offsets** to the old code for all 18 distinct timezone values currently in the dataset, and that the RFC-3339 formatting and current-deadline selection logic are unchanged. The one behavioral difference is defensive: an unmapped timezone now skips gracefully instead of panicking.

### Testing

- `cargo build` passes
- DST boundaries verified (Mar 8 2026 / Nov 1 2026 flip correctly; VLDB winter deadlines now resolve to UTC-8, summer to UTC-7)
- `vldb.yml` validates against the updated schema