### PR TITLE
Update REFSQ 2026 and ADMA 2026

### DIFF
--- a/conference/DB/adma.yml
+++ b/conference/DB/adma.yml
@@ -36,7 +36,7 @@
       id: adma26
       link: https://adma2026.github.io/
       timeline:
-        - deadline: 'TBD'
+        - deadline: '2026-06-26 23:59:59'
       timezone: AoE
-      date: November 1 - 3, 2026
+      date: November 13 - 15, 2026
       place: Hong Kong, China

--- a/conference/SE/refsq.yml
+++ b/conference/SE/refsq.yml
@@ -20,8 +20,8 @@
       id: refsq26
       link: https://2026.refsq.org/
       timeline:
-        - abstract_deadline: 'TBD'
-          deadline: 'TBD'
+        - abstract_deadline: '2025-10-10 23:59:59'
+          deadline: '2025-10-17 23:59:59'
       timezone: AoE
       date: March 23-26, 2026
       place: Poznań, Poland


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- REFSQ 2026 (already past due, only for completeness)
- ADMA 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://2026.refsq.org/dates
- https://adma2026.github.io/
