### PR TITLE
Update DCC CCF category according to the 2026 list

### DIFF
--- a/conference/CG/dcc.yml
+++ b/conference/CG/dcc.yml
@@ -1,6 +1,6 @@
 - title: DCC
   description: Data Compression Conference
-  sub: DS
+  sub: CG
   rank:
     ccf: B
     core: A*


### PR DESCRIPTION
### Which conference does this PR update?
- DCC

### Related URL
- https://ccf.atom.im/

### Changes
- Move DCC from DS to CG according to the CCF 2026 recommended list.
- DCC is listed as CCF B under Computer Graphics and Multimedia, not Computer Architecture/Parallel and Distributed Computing/Storage Systems.