### PR TITLE
Add missing DS CCF B conferences according to the 2026 CCF list

### DIFF
--- a/conference/DS/codesisss.yml
+++ b/conference/DS/codesisss.yml
@@ -1,0 +1,16 @@
+- title: CODES+ISSS
+  description: International Conference on Hardware/Software Co-design and System Synthesis
+  sub: DS
+  rank:
+    ccf: B
+  dblp: codes
+  confs:
+    - year: 2026
+      id: codesisss26
+      link: https://esweek.org/codes_isss_cfp/
+      timeline:
+        - abstract_deadline: '2026-03-23 23:59:59'
+          deadline: '2026-03-30 23:59:59'
+      timezone: AoE
+      date: October 4-9, 2026
+      place: Barcelona, Spain

--- a/conference/DS/hipeac.yml
+++ b/conference/DS/hipeac.yml
@@ -1,0 +1,15 @@
+- title: HiPEAC
+  description: International Conference on High Performance and Embedded Architectures and Compilers
+  sub: DS
+  rank:
+    ccf: B
+  dblp: hipeac
+  confs:
+    - year: 2027
+      id: hipeac27
+      link: https://www.hipeac.net/2027/glasgow/#/call-for-papers/
+      timeline:
+        - deadline: '2026-06-01 23:59:59'
+      timezone: AoE
+      date: January 18-20, 2027
+      place: Glasgow, Scotland, UK

--- a/conference/DS/lisa.yml
+++ b/conference/DS/lisa.yml
@@ -1,0 +1,15 @@
+- title: LISA
+  description: Large Installation System Administration Conference
+  sub: DS
+  rank:
+    ccf: B
+  dblp: lisa
+  confs:
+    - year: 2026
+      id: lisa26
+      link: https://www.usenix.org/conferences/byname/5
+      timeline:
+        - deadline: TBD
+      timezone: AoE
+      date: TBD
+      place: TBD

--- a/conference/DS/performance.yml
+++ b/conference/DS/performance.yml
@@ -1,0 +1,16 @@
+- title: Performance
+  description: International Symposium on Computer Performance, Modeling, Measurements and Evaluation
+  sub: DS
+  rank:
+    ccf: B
+  dblp: performance
+  confs:
+    - year: 2026
+      id: performance26
+      link: https://performance2026.github.io/call/
+      timeline:
+        - abstract_deadline: '2026-05-15 23:59:59'
+          deadline: '2026-05-22 23:59:59'
+      timezone: AoE
+      date: November 3-5, 2026
+      place: Ghent, Belgium


### PR DESCRIPTION
### Which conference does this PR update?
- CODES+ISSS
- HiPEAC
- Performance
- LISA

### Related URL
- https://ccf.atom.im/
- https://esweek.org/codes_isss_cfp/
- https://www.hipeac.net/2027/glasgow/#/call-for-papers/
- https://performance2026.github.io/call/
- https://www.usenix.org/conferences/byname/5

### Changes
- Add missing DS CCF B conferences according to the CCF 2026 recommended list.
- Use TBD for LISA fields where no current conference deadline information is available.