### PR TITLE
Update DCC Info & Remove LISA

### DIFF
--- a/conference/CG/dcc.yml
+++ b/conference/CG/dcc.yml
@@ -3,7 +3,7 @@
   sub: CG
   rank:
     ccf: B
-    core: A*
+    core: B
     thcpl: B
   dblp: dcc
   confs:
@@ -12,14 +12,14 @@
       link: https://datacompressionconference.org/
       timeline:
         - deadline: '2024-10-11 23:59:59'
-      timezone: UTC-8
+      timezone: PT
       date: March 18-21, 2025
-      place: Snowbird, Utah, U.S.
+      place: Snowbird, Utah, United States
     - year: 2027
       id: dcc2027
       link: https://datacompressionconference.org/
       timeline:
         - deadline: '2026-10-02 23:59:59'
-      timezone: AoE
+      timezone: PT
       date: March 23-26, 2027
-      place: The Cliff Lodge convention center, Snowbird, Utah, U.S.
+      place: Snowbird, Utah, United States

--- a/conference/DS/lisa.yml
+++ b/conference/DS/lisa.yml
@@ -3,13 +3,15 @@
   sub: DS
   rank:
     ccf: B
+    core: N
+    thcpl: N
   dblp: lisa
   confs:
-    - year: 2026
-      id: lisa26
-      link: https://www.usenix.org/conferences/byname/5
+    - year: 2021
+      id: lisa21
+      link: https://www.usenix.org/conference/lisa21
       timeline:
-        - deadline: TBD
-      timezone: AoE
-      date: TBD
-      place: TBD
+        - deadline: '2021-02-23 20:59:59'
+      timezone: PT
+      date: June 1-3, 2021
+      place: Virtual Event


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- LISA 2021 (Last conference added and removed LISA 2026 which does not exist)
- DCC

### Related URL
<!-- List useful URLs for reviewers to check -->
- LISA stopped being held: https://www.usenix.org/publications/loginonline/lisa-made-lisa-obsolete-thats-compliment
- DCC: https://datacompressionconference.org/
