### PR TITLE
Change core rank from 'N' to 'C' in acml.yml

### DIFF
--- a/conference/AI/acml.yml
+++ b/conference/AI/acml.yml
@@ -3,7 +3,7 @@
   sub: AI
   rank:
     ccf: C
-    core: N
+    core: C
     thcpl: N
   dblp: acml
   confs:


### PR DESCRIPTION
Core ranking of ACML has been changed to C in 2026 from Non-Core.

Core portal: https://portal.core.edu.au/conf-ranks/2174/

<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- ACML-26

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://portal.core.edu.au/conf-ranks/2174/
