### PR TITLE
Update PRICAI & WACV 2026 date and ACML core ranking

### DIFF
--- a/conference/AI/acml.yml
+++ b/conference/AI/acml.yml
@@ -3,7 +3,7 @@
   sub: AI
   rank:
     ccf: C
-    core: N
+    core: C
     thcpl: N
   dblp: acml
   confs:

--- a/conference/AI/pricai.yml
+++ b/conference/AI/pricai.yml
@@ -27,7 +27,7 @@
       id: pricai2026
       link: https://2026.pricai.org/
       timeline:
-        - deadline: '2026-06-13 23:59:59'
+        - deadline: '2026-06-27 23:59:59'
       timezone: UTC-12
       date: Nov 17-20, 2026
       place: Guangzhou, China

--- a/conference/AI/wacv.yml
+++ b/conference/AI/wacv.yml
@@ -35,11 +35,11 @@
       id: wacv27
       link: https://wacv.thecvf.com/
       timeline:
-        - abstract_deadline: '2026-06-18 23:59:00'
-          deadline: '2026-06-25 23:59:59'
+        - abstract_deadline: '2026-06-19 23:59:00'
+          deadline: '2026-06-26 23:59:59'
           comment: First round
-        - abstract_deadline: '2026-08-20 23:59:00'
-          deadline: '2026-08-27 23:59:59'
+        - abstract_deadline: '2026-08-21 23:59:00'
+          deadline: '2026-08-28 23:59:59'
           comment: Second round
       timezone: AoE
       date: Jan 5 - 9, 2027


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- PRICAI 2026
- ACML Core ranking 2026
- WACV 2026

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://2026.pricai.org/
- https://wacv.thecvf.com/Conferences/2027/Dates
