### PR TITLE
Update ACML 2026 conference deadline

### DIFF
--- a/conference/AI/acml.yml
+++ b/conference/AI/acml.yml
@@ -48,7 +48,7 @@
       timeline:
         - deadline: '2026-06-20 23:59:59'
           comment: 'Journal Track'
-        - deadline: '2026-06-26 23:59:59'
+        - deadline: '2026-07-05 23:59:59'
           comment: 'Conference Track'
       timezone: AoE
       date: December 1-4, 2026


### PR DESCRIPTION
## Summary

- Update the ACML 2026 Conference Track deadline from `2026-06-26 23:59:59` to `2026-07-05 23:59:59`.
- Keep the existing `AoE` timezone and other ACML 2026 metadata unchanged.

## Source

The official ACML 2026 Call for Papers now lists the Conference Track submission deadline as `05 July 2026` and shows the previous `26 June 2026` date as struck through:

https://www.acml-conf.org/2026/calls/papers/

## Validation

- `python3 scripts/validate.py`
