### PR TITLE
Update ACL series

### DIFF
--- a/conference/AI/acl.yml
+++ b/conference/AI/acl.yml
@@ -51,3 +51,12 @@
       timezone: UTC-12
       date: July 2 - 7, 2026
       place: San Diego, California, United States
+    - year: 2027
+      id: acl27
+      link: https://2027.aclweb.org/
+      timeline:
+        - deadline: 'TBD'
+          comment: 'ARR Submission'
+      timezone: UTC-12
+      date: August 17-22, 2027
+      place: Kyoto, Japan

--- a/conference/AI/coling.yml
+++ b/conference/AI/coling.yml
@@ -38,7 +38,7 @@
       id: coling27
       link: https://coling2027.org/
       timeline:
-        - deadline: 'TBD'
+        - deadline: '2026-10-12 23:59:59'
           comment: 'ARR Submission'
       timezone: UTC-12
       date: May 9-14, 2027

--- a/conference/AI/coling.yml
+++ b/conference/AI/coling.yml
@@ -38,7 +38,7 @@
       id: coling27
       link: https://2027.coling-iccl.org/
       timeline:
-        - deadline: '2026-10-12 23:59:59'
+        - deadline: 'TBD'
           comment: 'ARR Submission'
       timezone: UTC-12
       date: May 9-14, 2027

--- a/conference/AI/coling.yml
+++ b/conference/AI/coling.yml
@@ -36,7 +36,7 @@
       place: Abu Dhabi, UAE
     - year: 2027
       id: coling27
-      link: https://coling2027.org/
+      link: https://2027.coling-iccl.org/
       timeline:
         - deadline: '2026-10-12 23:59:59'
           comment: 'ARR Submission'

--- a/conference/AI/coling.yml
+++ b/conference/AI/coling.yml
@@ -34,3 +34,12 @@
       timezone: UTC-12
       date: Jan 19 - Jan 24, 2025
       place: Abu Dhabi, UAE
+    - year: 2027
+      id: coling27
+      link: https://coling2027.org/
+      timeline:
+        - deadline: 'TBD'
+          comment: 'ARR Submission'
+      timezone: UTC-12
+      date: May 9-14, 2027
+      place: Macau SAR, China

--- a/conference/AI/eacl.yml
+++ b/conference/AI/eacl.yml
@@ -20,6 +20,7 @@
       link: https://2027.eacl.org/
       timeline:
         - deadline: '2026-08-03 23:59:59'
-      timezone: AoE
+          comment: 'ARR Submission; commitment deadline: 2026-10-11'
+      timezone: UTC-12
       date: March 9-14, 2027
       place: Athens, Greece

--- a/conference/AI/emnlp.yml
+++ b/conference/AI/emnlp.yml
@@ -46,6 +46,7 @@
       link: https://2026.emnlp.org/
       timeline:
         - deadline: '2026-05-25 23:59:59'
+          comment: 'ARR Submission; commitment deadline: 2026-08-02'
       timezone: UTC-12
       date: October 24 - 29, 2026
       place: Budapest, Hungary

--- a/conference/AI/ijcnlp.yml
+++ b/conference/AI/ijcnlp.yml
@@ -21,7 +21,7 @@
       link: https://2026.aaclnet.org/
       timeline:
         - deadline: '2026-05-25 23:59:59'
-          comment: 'ARR Submission; AACL-IJCNLP 2026 (the 5th AACL & 15th IJCNLP)'
+          comment: 'ARR Submission; commitment deadline: 2026-08-02; AACL-IJCNLP 2026 (the 5th AACL & 15th IJCNLP)'
       timezone: UTC-12
       date: Nov 6-10, 2026
-      place: Hengqin, China
+      place: Hengqin, Zhuhai, China

--- a/conference/AI/naacl.yml
+++ b/conference/AI/naacl.yml
@@ -31,3 +31,12 @@
       timezone: UTC-12
       date: April 29-May 4, 2025
       place: Albuquerque, New Mexico, USA
+    - year: 2027
+      id: naacl27
+      link: https://2027.naacl.org/
+      timeline:
+        - deadline: 'TBD'
+          comment: 'ARR Submission'
+      timezone: UTC-12
+      date: June 1-5, 2027
+      place: San Francisco, California, USA

--- a/conference/AI/naacl.yml
+++ b/conference/AI/naacl.yml
@@ -35,7 +35,7 @@
       id: naacl27
       link: https://2027.naacl.org/
       timeline:
-        - deadline: 'TBD'
+        - deadline: '2026-10-12 23:59:59'
           comment: 'ARR Submission'
       timezone: UTC-12
       date: June 1-5, 2027


### PR DESCRIPTION
### Which conference does this PR update?
- EMNLP 2026
- AACL-IJCNLP 2026
- EACL 2027
- COLING 2027
- NAACL 2027
- ACL 2027

### Related URL
- https://aclrollingreview.org/dates
- https://2026.emnlp.org/
- https://2026.aaclnet.org/
- https://2027.eacl.org/
- https://coling2027.org/
- https://2027.naacl.org/
- https://2027.aclweb.org/

**Note: Some of the information is not yet on the website, and was announced on the closing remarks of ACL 2026 today**