### PR TITLE
Update WWW 2027

### DIFF
--- a/conference/MX/www.yml
+++ b/conference/MX/www.yml
@@ -68,5 +68,5 @@
         - abstract_deadline: '2026-10-11 23:59:59'
           deadline: '2026-10-18 23:59:59'
       timezone: AoE
-      date: May 10th - May 14th 2027
+      date: May 10 - 14, 2027
       place: Dublin, Ireland

--- a/conference/MX/www.yml
+++ b/conference/MX/www.yml
@@ -63,10 +63,10 @@
       place: Dubaï, UAE
     - year: 2027
       id: www27
-      link: https://www2027.thewebconf.org/
+      link: https://acmweb2027.org/
       timeline:
-        - abstract_deadline: 'TBD'
-          deadline: 'TBD'
+        - abstract_deadline: '2026-10-11 23:59:59'
+          deadline: '2026-10-18 23:59:59'
       timezone: AoE
-      date: TBD
+      date: May 10th - May 14th 2027
       place: Dublin, Ireland


### PR DESCRIPTION
### Which conference does this PR update?
- WWW 2027

### Related URL
- https://acmweb2027.org/
