### PR TITLE
Fix AAAI-2027 deadline.

### DIFF
--- a/conference/AI/aaai.yml
+++ b/conference/AI/aaai.yml
@@ -56,8 +56,8 @@
       id: aaai27
       link: https://aaai.org/conference/aaai/aaai-27/
       timeline:
-        - abstract_deadline: '2026-07-20 23:59:59'
-          deadline: '2026-07-27 23:59:59'
+        - abstract_deadline: '2026-07-21 23:59:59'
+          deadline: '2026-07-28 23:59:59'
       timezone: UTC-12
       date: February 16-23, 2027
       place: Montréal, Québec, Canada


### PR DESCRIPTION


<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- AAAI_2027

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://aaai.org/conference/aaai/aaai-27/

```
July 21, 2026
Abstracts due at 11:59 PM UTC-12

July 28, 2026
Full papers due at 11:59 PM UTC-12
```