### PR TITLE
Update CORE ranking for WCNC and MMAsia

### DIFF
--- a/conference/CG/mmasia.yml
+++ b/conference/CG/mmasia.yml
@@ -3,7 +3,7 @@
   sub: CG
   rank:
     ccf: C
-    core: N
+    core: C
     thcpl: N
   dblp: mmasia
   confs:

--- a/conference/NW/wcnc.yml
+++ b/conference/NW/wcnc.yml
@@ -1,9 +1,9 @@
 - title: WCNC
-  description: Wireless Communications and Networking Conference
+  description: IEEE Wireless Communications and Networking Conference
   sub: NW
   rank:
     ccf: C
-    core: N
+    core: B
     thcpl: N
   dblp: wcnc
   confs:


### PR DESCRIPTION
<!-- Thank you for contributing to ccf-deadlines!

PR Title Format: Update conf_name conf_year
-->

### Which conference does this PR update?
<!-- List conf_name conf_year below-->
- WCNC
- MMAsia

### Related URL
<!-- List useful URLs for reviewers to check -->
- https://portal.core.edu.au/conf-ranks/

Note that MMAsia uses "MM_Asia" in CORE database