### PR TITLE
Update ICLR 2027

### DIFF
--- a/conference/AI/iclr.yml
+++ b/conference/AI/iclr.yml
@@ -59,8 +59,8 @@
       id: iclr27
       link: https://iclr.cc/Conferences/2027
       timeline:
-        - abstract_deadline: '2026-09-11 23:59:59'
-          deadline: '2026-09-16 23:59:59'
+        - abstract_deadline: '2026-09-18 23:59:59'
+          deadline: '2026-09-25 23:59:59'
       timezone: AoE
-      date: April 27-30, 2027
+      date: TBD
       place: San Francisco, CA, USA


### PR DESCRIPTION
### Which conference does this PR update?
- ICLR 2027 (latest)

### Related URL
- https://iclr.cc/Conferences/2027/CallForPapers
