### PR TITLE
Update mmasia 2026

### DIFF
--- a/conference/CG/mmasia.yml
+++ b/conference/CG/mmasia.yml
@@ -27,7 +27,7 @@
       id: mmasia26
       link: https://www.mmasia2026.org/
       timeline:
-        - deadline: '2026-08-03 23:59:59'
+        - deadline: '2026-08-14 23:59:59'
           comment: Regular Paper / Special Session Submission
       timezone: AoE
       date: December 15-18, 2026


### PR DESCRIPTION
### Which conference does this PR update?

- MMAsia 2026

### Related URL

- https://www.mmasia2026.org/

Update the Regular Paper / Special Session Submission deadline to 2026-08-14 23:59:59 AoE.