### PR TITLE
Update FPGA 2027

### DIFF
--- a/conference/DS/fpga.yml
+++ b/conference/DS/fpga.yml
@@ -55,9 +55,10 @@
       id: fpga2027
       link: https://www.isfpga.org/
       timeline:
+        - deadline: '2026-10-01 23:59:59'
+          comment: Abstracts Due
         - deadline: '2026-10-08 23:59:59'
-          abstract_deadline: '2026-10-01 23:59:59'
-          comment: 'No extensions'
+          comment: Submissions Due
       timezone: UTC-12
       date: March 14 - March 16, 2027
       place: Monterey, California, USA

--- a/conference/DS/fpga.yml
+++ b/conference/DS/fpga.yml
@@ -51,3 +51,13 @@
       timezone: UTC-12
       date: February 22 - February 24, 2026
       place: Monterey, California, USA
+    - year: 2027
+      id: fpga2027
+      link: https://www.isfpga.org/
+      timeline:
+        - deadline: '2026-10-08 23:59:59'
+          abstract_deadline: '2026-10-01 23:59:59'
+          comment: 'Abstracts Due: October 1, 2026 (No Extensions). Submissions Due: October 8, 2026 (No Extensions)'
+      timezone: UTC-12
+      date: March 14 - March 16, 2027
+      place: Monterey, California, USA

--- a/conference/DS/fpga.yml
+++ b/conference/DS/fpga.yml
@@ -57,7 +57,7 @@
       timeline:
         - deadline: '2026-10-08 23:59:59'
           abstract_deadline: '2026-10-01 23:59:59'
-          comment: 'Abstracts Due: October 1, 2026 (No Extensions). Submissions Due: October 8, 2026 (No Extensions)'
+          comment: 'No extensions'
       timezone: UTC-12
       date: March 14 - March 16, 2027
       place: Monterey, California, USA


### PR DESCRIPTION
### Which conference does this PR update?

FPGA -2027

### Related URL

https://dl.acm.org/conference/fpga

https://www.isfpga.org/call-for-papers/

