### PR TITLE
Update IMC/RTAS/Middleware/SYSTOR dates from official sites (2026-08-09)

### DIFF
--- a/conference/DS/rtas.yml
+++ b/conference/DS/rtas.yml
@@ -24,3 +24,13 @@
       timezone: AoE
       date: May 12-14, 2026
       place: Saint Malo, France
+    - year: 2027
+      id: rtas2027
+      link: https://2027.rtas.org/
+      timeline:
+        - deadline: '2026-11-05 23:59:59'
+          comment: Submission Deadline (Firm)
+      timezone: AoE
+      date: May 17-20, 2027
+      place: ''
+

--- a/conference/DS/rtas.yml
+++ b/conference/DS/rtas.yml
@@ -32,5 +32,4 @@
           comment: Submission Deadline (Firm)
       timezone: AoE
       date: May 17-20, 2027
-      place: ''
-
+      place: Boulder, Colorado

--- a/conference/DS/systor.yml
+++ b/conference/DS/systor.yml
@@ -31,3 +31,13 @@
       timezone: AoE
       date: September 8-9, 2025
       place: IBM Haifa, Israel
+    - year: 2026
+      id: systor26
+      link: https://www.systor.org/2026/
+      timeline:
+        - deadline: '2026-05-25 23:59:59'
+          comment: Full and Short Papers Track
+      timezone: AoE
+      date: September 8-9, 2026
+      place: Virtual
+

--- a/conference/DS/systor.yml
+++ b/conference/DS/systor.yml
@@ -40,4 +40,3 @@
       timezone: AoE
       date: September 8-9, 2026
       place: Virtual
-

--- a/conference/NW/imc.yml
+++ b/conference/NW/imc.yml
@@ -40,5 +40,5 @@
           deadline: '2026-04-29 23:59:59'
           comment: 'Cycle 2 Deadline'
       timezone: AoE
-      date: November 03-06, 2026
+      date: October 12-16, 2026
       place: Karlsruhe, Germany

--- a/conference/NW/imc.yml
+++ b/conference/NW/imc.yml
@@ -40,5 +40,5 @@
           deadline: '2026-04-29 23:59:59'
           comment: 'Cycle 2 Deadline'
       timezone: AoE
-      date: October 12-16, 2026
+      date: Oct 12-16, 2026
       place: Karlsruhe, Germany

--- a/conference/SE/middleware.yml
+++ b/conference/SE/middleware.yml
@@ -18,3 +18,17 @@
       timezone: AoE
       date: November 7-11, 2022
       place: Fairmont Le Château Frontenac, Québec City, Québec, Canada
+    - year: 2026
+      id: middleware26
+      link: https://middleware-conf.github.io/2026/
+      timeline:
+        - abstract_deadline: '2025-12-09 23:59:59'
+          deadline: '2025-12-12 23:59:59'
+          comment: Round 1
+        - abstract_deadline: '2026-05-29 23:59:59'
+          deadline: '2026-06-05 23:59:59'
+          comment: Round 2
+      timezone: AoE
+      date: December 14-18, 2026
+      place: Universitat Rovira i Virgili, Tarragona, Spain
+

--- a/conference/SE/middleware.yml
+++ b/conference/SE/middleware.yml
@@ -31,4 +31,3 @@
       timezone: AoE
       date: December 14-18, 2026
       place: Universitat Rovira i Virgili, Tarragona, Spain
-


### PR DESCRIPTION
## Summary
- **IMC 2026**: event dates `November 03-06` → `October 12-16` (matches official site)
- **RTAS 2027**: add edition (submission 2026-11-05 AoE, conference May 17-20 2027)
- **Middleware 2026**: add edition (R1/R2 deadlines, Dec 14-18 Tarragona)
- **SYSTOR 2026**: add edition (paper 2026-05-25 AoE, Sep 8-9 Virtual)

## Sources (fetched 2026-08-09)
- https://conferences.sigcomm.org/imc/2026/
- https://2027.rtas.org/
- https://middleware-conf.github.io/2026/important-dates/
- https://www.systor.org/2026/cfp/

## Test plan
- [ ] YAML still loads under existing site pipeline
- [ ] IMC 2026 appears with October dates
- [ ] RTAS/Middleware/SYSTOR 2026–2027 entries render on the deadlines site