### PR TITLE
Add ACNS 2027 deadlines

### DIFF
--- a/conference/SC/acns.yml
+++ b/conference/SC/acns.yml
@@ -51,3 +51,14 @@
       timezone: AoE
       date: June 22-25, 2026
       place: New York, United States
+    - year: 2027
+      id: acns27
+      link: https://acns2027.isg.rhul.ac.uk/
+      timeline:
+        - deadline: '2026-09-24 23:59:59'
+          comment: Cycle 1 Submission deadline
+        - deadline: '2027-01-21 23:59:59'
+          comment: Cycle 2 Submission deadline
+      timezone: AoE
+      date: June 28 - July 1, 2027
+      place: Royal Holloway, Egham, UK


### PR DESCRIPTION
Official site: https://acns2027.isg.rhul.ac.uk/ (retrieved 2026-08-12)

- Cycle 1 paper submission: 24 September 2026 (AoE)
- Cycle 2 paper submission: 21 January 2027 (AoE)
- Conference: June 28 - July 1, 2027, Royal Holloway, Egham, UK

Current file has no 2027 edition (last is 2026).