### PR TITLE
Add FSE 2027 deadlines

### DIFF
--- a/conference/SC/fse.yml
+++ b/conference/SC/fse.yml
@@ -67,3 +67,14 @@
       timezone: UTC-12
       date: March 23-27, 2026
       place: Singapore, Singapore
+    - year: 2027
+      id: fse27
+      link: https://fse.iacr.org/2027/
+      timeline:
+        - deadline: '2026-09-01 23:59:59'
+          comment: ToSC, Volume 2026, Issue 4 Submission deadline
+        - deadline: '2026-12-01 23:59:59'
+          comment: ToSC, Volume 2027, Issue 1 Submission deadline
+      timezone: UTC-12
+      date: May 24-28, 2027
+      place: Maastricht, Netherlands


### PR DESCRIPTION
Official: https://fse.iacr.org/2027/ (retrieved 2026-08-12)

- 1 Sep 2026: ToSC 2026 issue 4 submission date
- 1 Dec 2026: ToSC 2027 issue 1 submission date
- 23:59 AoE per https://tosc.iacr.org/ ("The deadline for Volume ... is ... 23:59 AoE")
- Conference: May 24-28, 2027, Maastricht, Netherlands

Current file has no 2027 edition (last is 2026).