### PR TITLE
Add HOST 2027

### DIFF
--- a/conference/SC/host.yml
+++ b/conference/SC/host.yml
@@ -1,0 +1,18 @@
+- title: HOST
+  description: International Symposium on Hardware Oriented Security and Trust
+  sub: SC
+  rank:
+    ccf: N
+  dblp: host
+  confs:
+    - year: 2027
+      id: host27
+      link: https://host.conferences.computer.org/2027/
+      timeline:
+        - deadline: '2026-11-01 23:59:59'
+          comment: Abstract Submission deadline (Winter round)
+        - deadline: '2026-11-08 23:59:59'
+          comment: Full Paper Submission deadline (Winter round)
+      timezone: AoE
+      date: May 3-6, 2027
+      place: Washington DC, USA


### PR DESCRIPTION
Add IEEE HOST 2027 (May 3-6, 2027, Washington DC, USA) — new conference entry.

- Winter round abstract: November 1, 2026 (AoE) / full paper: November 8, 2026 (AoE) — https://host.conferences.computer.org/2027/
- ccf: N (not in CCF recommended list)