### PR TITLE
Fix date display for registration deadline

### DIFF
--- a/src/components/showtable.rs
+++ b/src/components/showtable.rs
@@ -330,11 +330,13 @@ pub fn ShowTable() -> impl IntoView {
                                         DateTime::parse_from_rfc3339(&abs_ddl_str)
                                     {
                                         let formatted_abs_ddl = abs_datetime
-                                            .with_timezone(&current_timezone)
                                             .format("%b %e, %Y")
                                             .to_string();
-                                        let abs_note =
-                                            format!("abstract deadline on {}", formatted_abs_ddl);
+                                        let abs_note = format!(
+                                            "abstract deadline on {} {}",
+                                            formatted_abs_ddl,
+                                            display_deadline_timezone(&item.timezone)
+                                        );
                                         item.comment = Some(match &item.comment {
                                             Some(existing) if !existing.is_empty() => {
                                                 format!("{} ({}).", existing, abs_note)
@@ -1105,6 +1107,30 @@ fn parse_deadline_to_rfc3339(deadline: &str, tz: &str) -> Option<String> {
     } else {
         format!("{}T23:59:59{}", deadline, tz_offset)
     })
+}
+
+fn display_deadline_timezone(tz: &str) -> &str {
+    match tz {
+        // UTC-12 is the fixed-offset representation of Anywhere on Earth used
+        // by many entries. Naming both makes the convention clear to readers.
+        "UTC-12" => "AoE (UTC-12)",
+        _ => tz,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{display_deadline_timezone, parse_deadline_to_rfc3339};
+    use chrono::DateTime;
+
+    #[test]
+    fn abstract_deadline_keeps_the_source_calendar_date() {
+        let deadline = parse_deadline_to_rfc3339("2026-08-18 23:59:59", "UTC-12").unwrap();
+        let date = DateTime::parse_from_rfc3339(&deadline).unwrap();
+
+        assert_eq!(date.format("%b %e, %Y").to_string(), "Aug 18, 2026");
+        assert_eq!(display_deadline_timezone("UTC-12"), "AoE (UTC-12)");
+    }
 }
 
 const RANK_OPTIONS: &[(&str, &str)] = &[("A", "CCF A"), ("B", "CCF B"), ("C", "CCF C"), ("N", "Non-CCF")];


### PR DESCRIPTION
## Title

Fix misleading abstract deadline dates across time zones

## Summary

This PR fixes how abstract deadlines are displayed when converting them to the viewer’s local timezone.

## Problem

Abstract deadlines are stored in the conference’s timezone, but the UI previously converted the date to the viewer’s local timezone and omitted the original timezone.

For example, USENIX Security 2027 has an abstract deadline of:

```text
August 18, 2026, 23:59:59 AoE (UTC−12)
```

For users in UTC+8, this was displayed as:

```text
abstract deadline on Aug 19, 2026
```

This could incorrectly suggest that the deadline is August 19 AoE and cause users to miss the abstract registration deadline.

## Changes

- Preserve the abstract deadline’s original calendar date.
- Display the source timezone alongside the date.
- Label UTC−12 deadlines as `AoE (UTC-12)` for clarity.

The example above is now displayed as:

```text
abstract deadline on Aug 18, 2026 AoE (UTC-12)
```

This remains clear regardless of the user’s local timezone.

## Testing

Added a regression test verifying that:

- The August 18, 2026 UTC−12 deadline remains August 18 when formatted.
- UTC−12 is displayed as `AoE (UTC-12)`.