### PR TITLE
Add CVC 2027

### DIFF
--- a/conference/AI/cvc.yml
+++ b/conference/AI/cvc.yml
@@ -1,0 +1,15 @@
+- title: CVC
+  description: Computer Vision Conference
+  sub: AI
+  rank:
+    ccf: N
+  dblp: cvc
+  confs:
+    - year: 2027
+      id: cvc27
+      link: https://saiconference.com/CVC
+      timeline:
+        - deadline: '2026-10-01 23:59:00'
+      timezone: AoE
+      date: April 15-16, 2027
+      place: Amsterdam, Netherlands


### PR DESCRIPTION
### Which conference does this PR update?
- cvc 2027

### Related URL
- https://saiconference.com/CVC
- https://saiconference.com/CVC/CallforPapers
- https://dblp.org/db/conf/cvc/index.html

Adding the Computer Vision Conference (CVC) 2027 edition (Amsterdam, April 15-16, 2027). Round 2 submission deadline is October 1, 2026 (AoE). Not CCF-ranked, so `rank.ccf: N`.