### PR TITLE
Add SAI Computing Conference 2027

### DIFF
--- a/conference/MX/sai-computing.yml
+++ b/conference/MX/sai-computing.yml
@@ -1,0 +1,15 @@
+- title: SAI Computing Conference
+  description: Computing Conference (SAI)
+  sub: MX
+  rank:
+    ccf: N
+  dblp: sai
+  confs:
+    - year: 2027
+      id: computing27
+      link: https://saiconference.com/Computing
+      timeline:
+        - deadline: '2026-10-01 23:59:00'
+      timezone: AoE
+      date: July 8-9, 2027
+      place: London, United Kingdom


### PR DESCRIPTION
### Which conference does this PR update?
- sai-computing 2027

### Related URL
- https://saiconference.com/Computing
- https://saiconference.com/Computing/CallforPapers
- https://dblp.org/db/conf/sai/index.html

Adding the 15th Computing Conference 2027 (SAI, London, July 8-9, 2027). Round 1 submission deadline is October 1, 2026 (AoE). Filed under `sub: MX` since it spans multiple interdisciplinary tracks (architectures, AI/ML, computer vision, data science, cybersecurity, society, education). Not CCF-ranked, so `rank.ccf: N`.