### PR TITLE
fix(ical/rss): support PT timezone so VLDB deadlines reach the feeds

### DIFF
--- a/extensions/cli/ccfddl/convert_to_ical.py
+++ b/extensions/cli/ccfddl/convert_to_ical.py
@@ -3,7 +3,7 @@ import re
 import uuid
 from collections import defaultdict
 from itertools import combinations
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from icalendar import Calendar, Event, Timezone, TimezoneStandard
 
 
@@ -19,12 +19,32 @@ def load_mapping(path: str = "conference/types.yml"):
     return SUB_MAPPING
 
 
-def get_timezone(tz_str: str) -> timezone:
-    """将时区字符串转换为datetime.timezone对象"""
+def nth_sunday(year: int, month: int, n: int) -> date:
+    """返回该年月的第n个星期日"""
+    first = date(year, month, 1)
+    # date.weekday(): Monday=0 ... Sunday=6
+    return first + timedelta(days=(6 - first.weekday()) % 7 + 7 * (n - 1))
+
+
+def is_us_dst(day: date) -> bool:
+    """美国夏令时区间: 3月第2个星期日 至 11月第1个星期日"""
+    return nth_sunday(day.year, 3, 2) <= day < nth_sunday(day.year, 11, 1)
+
+
+def get_timezone(tz_str: str, on_date: date | None = None) -> timezone:
+    """将时区字符串转换为datetime.timezone对象
+
+    PT (美国太平洋时间) 会随夏令时变化: 夏令时为 UTC-7, 其余为 UTC-8。
+    未提供 on_date 时按标准时间 UTC-8 处理。
+    """
     if tz_str == "AoE":
         return timezone(timedelta(hours=-12))
     if tz_str == "UTC":
         return timezone.utc
+    if tz_str == "PT":
+        if on_date is not None and is_us_dst(on_date):
+            return timezone(timedelta(hours=-7))
+        return timezone(timedelta(hours=-8))
     match = re.match(r"UTC([+-])(\d{1,2})$", tz_str)
     if not match:
         raise ValueError(f"无效的时区格式: {tz_str}")
@@ -81,19 +101,9 @@ def convert_to_ical(
 
                 for entry in timeline:
                     try:
-                        tz = get_timezone(timezone_str)
+                        get_timezone(timezone_str)
                     except ValueError:
                         continue
-
-                    # 添加VTIMEZONE组件
-                    tz_offset = tz.utcoffset(datetime.now())
-                    offset_hours = tz_offset.total_seconds() // 3600
-                    tzid = f"UTC{offset_hours:+03.0f}:00"
-
-                    if tzid not in added_tzids:
-                        vtz = create_vtimezone(tz)
-                        cal.add_component(vtz)
-                        added_tzids.add(tzid)
 
                     # 收集所有需要处理的截止日期
                     deadlines_to_process = []
@@ -134,6 +144,19 @@ def convert_to_ical(
                                 is_all_day = True
                             except ValueError:
                                 continue  # 无效日期格式
+
+                        # 按截止日期解析时区 (PT 需要按日期判断夏令时)
+                        tz = get_timezone(timezone_str, deadline_dt.date())
+
+                        # 添加VTIMEZONE组件
+                        tz_offset = tz.utcoffset(datetime.now())
+                        offset_hours = tz_offset.total_seconds() // 3600
+                        tzid = f"UTC{offset_hours:+03.0f}:00"
+
+                        if tzid not in added_tzids:
+                            vtz = create_vtimezone(tz)
+                            cal.add_component(vtz)
+                            added_tzids.add(tzid)
 
                         # 创建事件对象
                         event = Event()

--- a/extensions/cli/ccfddl/convert_to_rss.py
+++ b/extensions/cli/ccfddl/convert_to_rss.py
@@ -51,7 +51,7 @@ def convert_to_rss(
 
                 for entry in timeline:
                     try:
-                        tz = get_timezone(timezone_str)
+                        get_timezone(timezone_str)
                     except ValueError:
                         continue
 
@@ -90,6 +90,8 @@ def convert_to_rss(
                             except ValueError:
                                 continue
 
+                        # 按截止日期解析时区 (PT 需要按日期判断夏令时)
+                        tz = get_timezone(timezone_str, deadline_dt.date())
                         aware_dt = deadline_dt.replace(tzinfo=tz)
 
                         item = ET.SubElement(channel, "item")

--- a/extensions/cli/ccfddl/tests/test_utils.py
+++ b/extensions/cli/ccfddl/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from ccfddl.utils import get_timezone, load_mapping, reverse_index
 
@@ -28,6 +28,25 @@ class TestGetTimezone:
         tz = get_timezone("UTC+0")
         expected = timezone(timedelta(hours=0))
         assert tz == expected
+
+    def test_pt_standard_time(self):
+        tz = get_timezone("PT", date(2026, 1, 1))
+        assert tz == timezone(timedelta(hours=-8))
+
+    def test_pt_daylight_saving(self):
+        tz = get_timezone("PT", date(2026, 7, 1))
+        assert tz == timezone(timedelta(hours=-7))
+
+    def test_pt_without_date_defaults_to_standard(self):
+        tz = get_timezone("PT")
+        assert tz == timezone(timedelta(hours=-8))
+
+    def test_pt_dst_boundaries(self):
+        # DST runs from the 2nd Sunday of March to the 1st Sunday of November
+        assert get_timezone("PT", date(2026, 3, 7)) == timezone(timedelta(hours=-8))
+        assert get_timezone("PT", date(2026, 3, 8)) == timezone(timedelta(hours=-7))
+        assert get_timezone("PT", date(2026, 10, 31)) == timezone(timedelta(hours=-7))
+        assert get_timezone("PT", date(2026, 11, 1)) == timezone(timedelta(hours=-8))
 
     def test_invalid_format(self):
         with pytest.raises(ValueError, match="Invalid timezone format"):

--- a/extensions/cli/ccfddl/utils.py
+++ b/extensions/cli/ccfddl/utils.py
@@ -6,7 +6,7 @@ and conference data processing.
 
 import re
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from itertools import combinations
 
 import yaml
@@ -31,16 +31,31 @@ def load_mapping(path: str = "conference/types.yml") -> dict[str, str]:
     return sub_mapping
 
 
-def get_timezone(tz_str: str) -> timezone:
+def nth_sunday(year: int, month: int, n: int) -> date:
+    """Return the nth Sunday of the given month."""
+    first = date(year, month, 1)
+    # date.weekday(): Monday=0 ... Sunday=6
+    return first + timedelta(days=(6 - first.weekday()) % 7 + 7 * (n - 1))
+
+
+def is_us_dst(day: date) -> bool:
+    """US daylight saving time: 2nd Sunday of March to 1st Sunday of November."""
+    return nth_sunday(day.year, 3, 2) <= day < nth_sunday(day.year, 11, 1)
+
+
+def get_timezone(tz_str: str, on_date: date | None = None) -> timezone:
     """Convert timezone string to datetime.timezone object.
 
     Supported formats:
         - 'AoE' (Anywhere on Earth, UTC-12)
         - 'UTC' (UTC+0)
         - 'UTC+8', 'UTC-5' (UTC with offset)
+        - 'PT' (US Pacific Time, UTC-7 during DST and UTC-8 otherwise)
 
     Args:
         tz_str: Timezone string
+        on_date: Date the deadline falls on, used to resolve daylight saving
+            labels such as 'PT'. Defaults to standard time when omitted.
 
     Returns:
         A timezone object
@@ -52,6 +67,10 @@ def get_timezone(tz_str: str) -> timezone:
         return timezone(timedelta(hours=-12))
     if tz_str == "UTC":
         return timezone.utc
+    if tz_str == "PT":
+        if on_date is not None and is_us_dst(on_date):
+            return timezone(timedelta(hours=-7))
+        return timezone(timedelta(hours=-8))
     match = re.match(r"UTC([+-])(\d{1,2})$", tz_str)
     if not match:
         raise ValueError(f"Invalid timezone format: {tz_str}")
@@ -76,8 +95,8 @@ def parse_datetime_with_tz(
     Raises:
         ValueError: If datetime or timezone format is invalid
     """
-    tz = get_timezone(tz_str)
     dt = datetime.strptime(dt_str, format_str)
+    tz = get_timezone(tz_str, dt.date())
     return dt.replace(tzinfo=tz)
 
 


### PR DESCRIPTION
## TLDR

订阅RSS Feed的时候 `VLDB`, `DCC`, `LISA` 会议的DDL全部都是空的，因为生成RSS Feed的脚本不处理Pacific时区；iCal订阅也有同样的问题。这个PR修复了这些问题，生成页面的其他部分不受影响。

点一下Merge谢谢喵。

以下是Claude生成的修复详情，很长。

---

## Problem

`VLDB`, `DCC` and `LISA` currently have **zero** events in every published iCal and RSS feed. `deadlines_en.ics` has 2033 events and not one of them is VLDB, even though `conference/DB/vldb.yml` holds 96 deadlines including all the rolling monthly ones.

The website shows them correctly — only the subscription feeds are affected, which is why this went unnoticed.

## Root cause

This is a regression from #1554.

That PR added `PT` to `conference-yaml-schema.yml`, taught the frontend to resolve it (`showtable.rs::resolve_tz_offset`), and switched `vldb.yml` from `timezone: UTC-7` to `timezone: PT`. The frontend half is correct and this PR does not change it.

What it missed is that the feed generators have their own timezone parser, which still accepts only `AoE`, `UTC` and `UTC±H`:

```python
# extensions/cli/ccfddl/convert_to_ical.py
try:
    tz = get_timezone(timezone_str)
except ValueError:
    continue          # ← whole timeline entry silently dropped
```

`PT` raises `ValueError`, the guard swallows it, and the entry never reaches the calendar. Because `vldb.yml` moved to `PT` in the same PR, VLDB went from 96 events to 0 the moment it merged. `PT` is the only one of the 19 timezone labels in the dataset that the generators cannot parse.

Worth noting: `MergeCheck` runs `merge.py` and `trunk build` but never invokes `convert_to_ical.py` / `convert_to_rss.py`. The generators only run in `Deploy`, after merge, and a dropped conference is not an error there — so CI could not have caught this and would not catch a recurrence.

## Fix

Resolve `PT` the same way the frontend does — UTC-7 during US DST (2nd Sunday of March → 1st Sunday of November), UTC-8 otherwise.

Since the offset depends on the date, the timezone is now resolved **per deadline** instead of once per timeline entry. That is also what makes VLDB's April→March rolling deadlines straddle the DST boundary correctly, rather than pinning the whole conference-year to one offset.

The same fix is applied to `ccfddl/utils.py`, the second copy of `get_timezone` used by the CLI through `parse_datetime_with_tz`. `ccfddl --conf VLDB` returned an empty table before this and now returns VLDB 2027.

## Impact on other conferences: none

I regenerated all 2516 feed files before and after, normalising the random `UID`/`DTSTAMP`/`lastBuildDate` fields, and diffed them event by event:

| | |
|---|---|
| Output files | 2516 before, 2516 after — identical filename set |
| Files with any difference | 180 |
| Events **added** | 99 — VLDB 96, DCC 2, LISA 1 |
| Events **removed** | **0** |
| Events **modified** | **0** |
| `VTIMEZONE` blocks added | 1 (`UTC-08:00`, in filtered feeds that previously contained no UTC-8 conference) |

The change is strictly additive. No conference other than the three that were being dropped sees any difference at all.

## Testing

- `pytest ccfddl/tests/` — 57 passed (53 existing, unchanged, plus 4 new PT cases covering both DST boundaries and the no-date default)
- Full `Deploy` pipeline run locally end to end: `validate.py` → `merge.py` (353 conferences) → `convert_to_ical.py` (1258 files) → `convert_to_rss.py` (1258 files), all exit 0
- All 2516 generated files re-parsed with `icalendar` / `ElementTree` — 0 failures
- `pre-commit run` — all hooks pass
- DST boundaries verified against the frontend's rules: 2026-03-07 → UTC-8, 2026-03-08 → UTC-7, 2026-10-31 → UTC-7, 2026-11-01 → UTC-8
- Spot check: `VLDB 2027` abstract deadline `2026-03-25 17:00` → `DTSTART;TZID="UTC-07:00":20260325T170000`; the `2026-12-01` deadline → `TZID="UTC-08:00"`

No Rust, YAML, schema or workflow files are touched.

## One thing left for maintainers to decide

I kept the `except ValueError: continue` guard as it is, so this PR stays a minimal fix. But that guard is what turned a one-line gap into three conferences vanishing from the feeds for months without a single warning. Raising it, or at least logging the skipped conference, would make the next unsupported label visible immediately. Happy to add that here or in a follow-up, whichever you prefer.

cc @sarendis56 — flagging you since this is the feed-side half of #1554; the frontend work there was correct and is untouched.
