### PR TITLE
Update NeurIPS 2026

### DIFF
--- a/conference/AI/nips.yml
+++ b/conference/AI/nips.yml
@@ -58,5 +58,5 @@
         - abstract_deadline: '2026-05-05 11:59:00'
           deadline: '2026-05-07 11:59:00'
       timezone: UTC+0
-      date: December 6, 2026
+      date: December 6-12, 2026
       place: Sydney, Australia


### PR DESCRIPTION
fix dates

- NeurIPS 2026

### Related URL
- https://neurips.cc/Conferences/2026
